### PR TITLE
250422_13_임명우

### DIFF
--- a/lib/core/di/app_di.dart
+++ b/lib/core/di/app_di.dart
@@ -15,8 +15,10 @@ import 'package:recipe_app/feature/receipe/domain/repository/search/search_recip
 import 'package:recipe_app/feature/receipe/domain/use_case/info/get_recipe_info_use_case.dart';
 import 'package:recipe_app/feature/receipe/domain/use_case/saved_recipes/bookmark_recipes_use_case.dart';
 import 'package:recipe_app/feature/receipe/domain/use_case/saved_recipes/get_recent_search_text_use_case.dart';
+import 'package:recipe_app/feature/receipe/domain/use_case/saved_recipes/get_recipes_use_case.dart';
 import 'package:recipe_app/feature/receipe/domain/use_case/saved_recipes/get_saved_recipes_use_case.dart';
 import 'package:recipe_app/feature/receipe/domain/use_case/saved_recipes/save_recent_search_text_use_case.dart';
+import 'package:recipe_app/feature/receipe/presentation/home/home_view_model.dart';
 import 'package:recipe_app/feature/receipe/presentation/info/recipe_info_view_model.dart';
 import 'package:recipe_app/feature/receipe/presentation/saved_recipes/saved_recipes_view_model.dart';
 import 'package:recipe_app/feature/receipe/presentation/search_recipes/search_view_model.dart';
@@ -46,6 +48,7 @@ void diSetup() {
   getIt.registerSingleton(GetRecentSearchTextUseCase(getIt()));
   getIt.registerSingleton(BookmarkRecipesUseCase(getIt()));
   getIt.registerSingleton(SaveRecentSearchTextUseCase(getIt()));
+  getIt.registerSingleton(GetRecipesUseCase(getIt()));
 
   // 뷰모델
   getIt.registerFactory(
@@ -63,4 +66,5 @@ void diSetup() {
     ),
   );
   getIt.registerFactory(() => SplashViewModel());
+  getIt.registerFactory(() => HomeViewModel(getIt()));
 }

--- a/lib/core/router/routes.dart
+++ b/lib/core/router/routes.dart
@@ -10,8 +10,10 @@ import 'package:recipe_app/feature/receipe/presentation/home/home_screen.dart';
 import 'package:recipe_app/feature/notification/presentation/pages/notification_screen.dart';
 import 'package:recipe_app/feature/profile/presentation/pages/profile_screen.dart';
 import 'package:recipe_app/feature/receipe/presentation/info/recipe_info_screen.dart';
+import 'package:recipe_app/feature/receipe/presentation/info/recipe_info_screen_root.dart';
 import 'package:recipe_app/feature/receipe/presentation/info/recipe_info_view_model.dart';
 import 'package:recipe_app/feature/receipe/presentation/saved_recipes/saved_recipes_screen.dart';
+import 'package:recipe_app/feature/receipe/presentation/saved_recipes/saved_recipes_screen_root.dart';
 import 'package:recipe_app/feature/receipe/presentation/saved_recipes/saved_recipes_view_model.dart';
 import 'package:recipe_app/feature/receipe/presentation/search_recipes/search_screen.dart';
 import 'package:recipe_app/core/presentation/pages/splash/splash_screen.dart';
@@ -62,7 +64,7 @@ final routes = [
     builder: (context, state) {
       final id = state.pathParameters['id']!;
       final RecipeInfoViewModel viewModel = getIt();
-      return RecipeInfoScreen(id: int.parse(id), viewModel: viewModel);
+      return RecipeInfoScreenRoot(id: int.parse(id), viewModel: viewModel);
     },
   ),
 
@@ -82,7 +84,7 @@ final routes = [
         path: AppRoutes.savedRecipes,
         builder: (context, state) {
           final SavedRecipesViewModel viewModel = getIt();
-          return SavedRecipesScreen(viewModel);
+          return SavedRecipesScreenRoot(viewModel);
         },
       ),
 

--- a/lib/core/router/routes.dart
+++ b/lib/core/router/routes.dart
@@ -15,6 +15,7 @@ import 'package:recipe_app/feature/receipe/presentation/saved_recipes/saved_reci
 import 'package:recipe_app/feature/receipe/presentation/saved_recipes/saved_recipes_view_model.dart';
 import 'package:recipe_app/feature/receipe/presentation/search_recipes/search_screen.dart';
 import 'package:recipe_app/core/presentation/pages/splash/splash_screen.dart';
+import 'package:recipe_app/feature/receipe/presentation/search_recipes/search_screen_root.dart';
 import 'package:recipe_app/feature/receipe/presentation/search_recipes/search_view_model.dart';
 
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
@@ -51,7 +52,7 @@ final routes = [
     path: AppRoutes.search,
     builder: (context, state) {
       final SearchViewModel viewModel = getIt();
-      return SearchScreen(viewModel);
+      return SearchScreenRoot(viewModel);
     },
   ),
 

--- a/lib/core/router/routes.dart
+++ b/lib/core/router/routes.dart
@@ -6,16 +6,13 @@ import 'package:recipe_app/core/presentation/pages/root_tab.dart';
 import 'package:recipe_app/core/presentation/pages/splash/splash_view_model.dart';
 import 'package:recipe_app/feature/auth/presentation/pages/sign_up_screen.dart';
 import 'package:recipe_app/feature/auth/presentation/pages/sing_in_screen.dart';
-import 'package:recipe_app/feature/receipe/presentation/home/home_screen.dart';
 import 'package:recipe_app/feature/notification/presentation/pages/notification_screen.dart';
 import 'package:recipe_app/feature/profile/presentation/pages/profile_screen.dart';
-import 'package:recipe_app/feature/receipe/presentation/info/recipe_info_screen.dart';
+import 'package:recipe_app/feature/receipe/presentation/home/home_screen_root.dart';
 import 'package:recipe_app/feature/receipe/presentation/info/recipe_info_screen_root.dart';
 import 'package:recipe_app/feature/receipe/presentation/info/recipe_info_view_model.dart';
-import 'package:recipe_app/feature/receipe/presentation/saved_recipes/saved_recipes_screen.dart';
 import 'package:recipe_app/feature/receipe/presentation/saved_recipes/saved_recipes_screen_root.dart';
 import 'package:recipe_app/feature/receipe/presentation/saved_recipes/saved_recipes_view_model.dart';
-import 'package:recipe_app/feature/receipe/presentation/search_recipes/search_screen.dart';
 import 'package:recipe_app/core/presentation/pages/splash/splash_screen.dart';
 import 'package:recipe_app/feature/receipe/presentation/search_recipes/search_screen_root.dart';
 import 'package:recipe_app/feature/receipe/presentation/search_recipes/search_view_model.dart';
@@ -77,7 +74,7 @@ final routes = [
       GoRoute(
         path: AppRoutes.home,
         builder: (context, state) {
-          return const HomeScreen();
+          return HomeScreenRoot(getIt());
         },
       ),
       GoRoute(

--- a/lib/feature/receipe/data/data_source/search/mock/mock_search_recipe_data_source_impl.dart
+++ b/lib/feature/receipe/data/data_source/search/mock/mock_search_recipe_data_source_impl.dart
@@ -16,6 +16,7 @@ class MockSearchRecipeDataSourceImpl implements SearchRecipeDataSource {
         "chef": "Chef John",
         "time": "20 min",
         "rating": 4.0,
+        "bookmarkStatus": true,
         "ingredients": [
           {
             "ingredient": {
@@ -64,6 +65,7 @@ class MockSearchRecipeDataSourceImpl implements SearchRecipeDataSource {
         "chef": "Mark Kelvin",
         "time": "20 min",
         "rating": 4.0,
+        "bookmarkStatus": true,
         "ingredients": [
           {
             "ingredient": {
@@ -112,6 +114,7 @@ class MockSearchRecipeDataSourceImpl implements SearchRecipeDataSource {
         "chef": "Spicy Nelly",
         "time": "20 min",
         "rating": 4.0,
+        "bookmarkStatus": true,
         "ingredients": [
           {
             "ingredient": {
@@ -151,6 +154,7 @@ class MockSearchRecipeDataSourceImpl implements SearchRecipeDataSource {
         "chef": "Kim Dahee",
         "time": "30 min",
         "rating": 5.0,
+        "bookmarkStatus": true,
         "ingredients": [],
       },
       {
@@ -162,6 +166,7 @@ class MockSearchRecipeDataSourceImpl implements SearchRecipeDataSource {
         "chef": "Alice Johnson",
         "time": "25 min",
         "rating": 4.5,
+        "bookmarkStatus": true,
         "ingredients": [
           {
             "ingredient": {
@@ -192,6 +197,7 @@ class MockSearchRecipeDataSourceImpl implements SearchRecipeDataSource {
         "chef": "Gordon Ramsay",
         "time": "45 min",
         "rating": 5.0,
+        "bookmarkStatus": true,
         "ingredients": [
           {
             "ingredient": {
@@ -222,6 +228,7 @@ class MockSearchRecipeDataSourceImpl implements SearchRecipeDataSource {
         "chef": "Mario Batali",
         "time": "15 min",
         "rating": 4.3,
+        "bookmarkStatus": true,
         "ingredients": [
           {
             "ingredient": {
@@ -243,6 +250,7 @@ class MockSearchRecipeDataSourceImpl implements SearchRecipeDataSource {
         "chef": "Jiro Ono",
         "time": "60 min",
         "rating": 4.8,
+        "bookmarkStatus": true,
         "ingredients": [
           {
             "ingredient": {
@@ -273,6 +281,7 @@ class MockSearchRecipeDataSourceImpl implements SearchRecipeDataSource {
         "chef": "Julia Child",
         "time": "40 min",
         "rating": 4.6,
+        "bookmarkStatus": true,
         "ingredients": [
           {
             "ingredient": {
@@ -294,6 +303,7 @@ class MockSearchRecipeDataSourceImpl implements SearchRecipeDataSource {
         "chef": "Paul Hollywood",
         "time": "30 min",
         "rating": 4.9,
+        "bookmarkStatus": true,
         "ingredients": [
           {
             "ingredient": {

--- a/lib/feature/receipe/domain/use_case/saved_recipes/get_recipes_use_case.dart
+++ b/lib/feature/receipe/domain/use_case/saved_recipes/get_recipes_use_case.dart
@@ -1,0 +1,14 @@
+import 'package:recipe_app/core/modules/error_handling/result.dart';
+import 'package:recipe_app/feature/receipe/domain/model/recipe.dart';
+import 'package:recipe_app/feature/receipe/domain/repository/search/search_recipe_repository.dart';
+
+class GetRecipesUseCase {
+  final SearchRecipeRepository _searchRecipeRepository;
+
+  GetRecipesUseCase(this._searchRecipeRepository);
+
+  Future<Result<List<Recipe>>> excute() {
+    final result = _searchRecipeRepository.getRecipes();
+    return result;
+  }
+}

--- a/lib/feature/receipe/presentation/filter_modal/filter_search_screen.dart
+++ b/lib/feature/receipe/presentation/filter_modal/filter_search_screen.dart
@@ -96,7 +96,6 @@ class FilterSearch extends StatelessWidget {
                 child: AppButton(
                   text: 'Filter',
                   onClick: () {
-                    viewModel.filterData();
                     Navigator.pop(context);
                   },
                   type: ButtonType.small,

--- a/lib/feature/receipe/presentation/filter_modal/filter_search_view_model.dart
+++ b/lib/feature/receipe/presentation/filter_modal/filter_search_view_model.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:recipe_app/feature/receipe/presentation/filter_modal/filter_search_state.dart';
-import 'package:recipe_app/feature/receipe/presentation/search_recipes/search_view_model.dart';
 
 class FilterSearchViewModel with ChangeNotifier {
-  final SearchViewModel _searchViewModel;
-  FilterSearchViewModel(this._searchViewModel);
+  FilterSearchViewModel();
 
   FilterSearchState _originalState = const FilterSearchState();
   FilterSearchState _state = const FilterSearchState();
@@ -33,16 +31,5 @@ class FilterSearchViewModel with ChangeNotifier {
   // 데이터 리셋
   void resetData() {
     _state = _originalState.copyWith();
-  }
-
-  // 데이터 필터링
-  void filterData() {
-    changeOriginalData();
-    notifyListeners();
-    _searchViewModel.filterData(
-      time: _state.time,
-      rate: _state.rate,
-      category: _state.category,
-    );
   }
 }

--- a/lib/feature/receipe/presentation/home/home_action.dart
+++ b/lib/feature/receipe/presentation/home/home_action.dart
@@ -1,0 +1,13 @@
+sealed class HomeAction {
+  const factory HomeAction.getRecipes() = GetRecipes;
+  const factory HomeAction.sortRecipes(String text) = SortRecipes;
+}
+
+class GetRecipes implements HomeAction {
+  const GetRecipes();
+}
+
+class SortRecipes implements HomeAction {
+  final String text;
+  const SortRecipes(this.text);
+}

--- a/lib/feature/receipe/presentation/home/home_screen.dart
+++ b/lib/feature/receipe/presentation/home/home_screen.dart
@@ -1,23 +1,29 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:recipe_app/core/enum/state_enum.dart';
 import 'package:recipe_app/core/router/routes.dart';
 import 'package:recipe_app/core/style/app_color.dart';
 import 'package:recipe_app/core/style/app_textstyle.dart';
 import 'package:recipe_app/core/presentation/pages/base_screen.dart';
 import 'package:recipe_app/core/presentation/widgets/textfield/search_textfield.dart';
+import 'package:recipe_app/feature/receipe/presentation/home/home_action.dart';
+import 'package:recipe_app/feature/receipe/presentation/home/home_state.dart';
+import 'package:recipe_app/feature/receipe/presentation/widgets/filter_button.dart';
 import 'package:recipe_app/feature/receipe/presentation/widgets/filter_search_button.dart';
+import 'package:recipe_app/feature/receipe/presentation/widgets/home_card.dart';
 
-class HomeScreen extends StatefulWidget {
-  const HomeScreen({super.key});
+class HomeScreen extends StatelessWidget {
+  final HomeState state;
+  final void Function(HomeAction action) onAction;
+  const HomeScreen({required this.state, required this.onAction, super.key});
 
-  @override
-  State<HomeScreen> createState() => _HomeScreenState();
-}
-
-class _HomeScreenState extends State<HomeScreen> {
-  final _search = TextEditingController();
   @override
   Widget build(BuildContext context) {
+    if (state.state == ViewState.loading) {
+      return const BaseScreen(
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
     return BaseScreen(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 30),
@@ -60,7 +66,7 @@ class _HomeScreenState extends State<HomeScreen> {
                 children: [
                   Expanded(
                     child: SearchTextfield(
-                      controller: _search,
+                      controller: TextEditingController(),
                       onChanged: (val) {},
                       enabled: false,
                     ),
@@ -70,9 +76,58 @@ class _HomeScreenState extends State<HomeScreen> {
                 ],
               ),
             ),
+            SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 20),
+                child: Row(
+                  children:
+                      _categories
+                          .map(
+                            (e) => Padding(
+                              padding: const EdgeInsets.only(right: 8),
+                              child: FilterButton(
+                                text: e,
+                                isSelected: state.filter == e,
+                                onTap: () {
+                                  onAction(HomeAction.sortRecipes(e));
+                                },
+                              ),
+                            ),
+                          )
+                          .toList(),
+                ),
+              ),
+            ),
+            SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                children:
+                    state.filteredRecipes
+                        .map(
+                          (e) => Padding(
+                            padding: const EdgeInsets.only(right: 12),
+                            child: HomeCard(e),
+                          ),
+                        )
+                        .toList(),
+              ),
+            ),
           ],
         ),
       ),
     );
   }
+
+  List<String> get _categories => [
+    'All',
+    'Indian',
+    'Asian',
+    'Chinese',
+    'Japanese',
+    'American',
+    'British',
+    'Italian',
+    'French',
+  ];
 }

--- a/lib/feature/receipe/presentation/home/home_screen_root.dart
+++ b/lib/feature/receipe/presentation/home/home_screen_root.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:recipe_app/feature/receipe/presentation/home/home_action.dart';
+import 'package:recipe_app/feature/receipe/presentation/home/home_screen.dart';
+import 'package:recipe_app/feature/receipe/presentation/home/home_view_model.dart';
+
+class HomeScreenRoot extends StatefulWidget {
+  final HomeViewModel viewModel;
+  const HomeScreenRoot(this.viewModel, {super.key});
+
+  @override
+  State<HomeScreenRoot> createState() => _HomeScreenRootState();
+}
+
+class _HomeScreenRootState extends State<HomeScreenRoot> {
+  @override
+  void initState() {
+    widget.viewModel.onAction(const HomeAction.getRecipes());
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: widget.viewModel,
+      builder: (child, context) {
+        return HomeScreen(
+          state: widget.viewModel.state,
+          onAction: widget.viewModel.onAction,
+        );
+      },
+    );
+  }
+}

--- a/lib/feature/receipe/presentation/home/home_state.dart
+++ b/lib/feature/receipe/presentation/home/home_state.dart
@@ -1,0 +1,29 @@
+import 'package:recipe_app/core/enum/state_enum.dart';
+import 'package:recipe_app/feature/receipe/domain/model/recipe.dart';
+
+class HomeState {
+  final ViewState state;
+  final List<Recipe> recipes;
+  final List<Recipe> filteredRecipes;
+  final String filter;
+  const HomeState({
+    this.state = ViewState.loading,
+    this.recipes = const [],
+    this.filteredRecipes = const [],
+    this.filter = 'All',
+  });
+
+  HomeState copyWith({
+    ViewState? state,
+    List<Recipe>? recipes,
+    List<Recipe>? filteredRecipes,
+    String? filter,
+  }) {
+    return HomeState(
+      state: state ?? this.state,
+      recipes: recipes ?? this.recipes,
+      filteredRecipes: filteredRecipes ?? this.filteredRecipes,
+      filter: filter ?? this.filter,
+    );
+  }
+}

--- a/lib/feature/receipe/presentation/home/home_view_model.dart
+++ b/lib/feature/receipe/presentation/home/home_view_model.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/foundation.dart';
+import 'package:recipe_app/core/enum/state_enum.dart';
+import 'package:recipe_app/core/modules/error_handling/result.dart';
+import 'package:recipe_app/feature/receipe/domain/model/recipe.dart';
+import 'package:recipe_app/feature/receipe/domain/use_case/saved_recipes/get_recipes_use_case.dart';
+import 'package:recipe_app/feature/receipe/presentation/home/home_action.dart';
+import 'package:recipe_app/feature/receipe/presentation/home/home_state.dart';
+
+class HomeViewModel with ChangeNotifier {
+  final GetRecipesUseCase _getRecipesUseCase;
+
+  HomeViewModel(this._getRecipesUseCase);
+
+  HomeState _state = const HomeState();
+  HomeState get state => _state;
+
+  void onAction(HomeAction action) {
+    switch (action) {
+      case GetRecipes():
+        _getRecipes();
+      case SortRecipes():
+        _sortRecipes(action.text);
+    }
+  }
+
+  void _sortRecipes(String text) async {
+    _state = state.copyWith(
+      filter: text,
+      filteredRecipes:
+          text == 'All'
+              ? state.recipes
+              : state.recipes.where((e) => e.category == text).toList(),
+    );
+    notifyListeners();
+  }
+
+  void _getRecipes() async {
+    _state = state.copyWith(state: ViewState.loading);
+    notifyListeners();
+    final result = await _getRecipesUseCase.excute();
+    switch (result) {
+      case Success<List<Recipe>>():
+        _state = state.copyWith(
+          state: ViewState.complete,
+          recipes: result.data,
+          filteredRecipes: result.data,
+        );
+      case Error<List<Recipe>>():
+        _state = state.copyWith(state: ViewState.error);
+    }
+    notifyListeners();
+  }
+}

--- a/lib/feature/receipe/presentation/info/recipe_info_action.dart
+++ b/lib/feature/receipe/presentation/info/recipe_info_action.dart
@@ -1,0 +1,8 @@
+sealed class RecipeInfoAction {
+  const factory RecipeInfoAction.getRecipeInfo(int id) = GetRecipeInfo;
+}
+
+class GetRecipeInfo implements RecipeInfoAction {
+  final int id;
+  const GetRecipeInfo(this.id);
+}

--- a/lib/feature/receipe/presentation/info/recipe_info_screen.dart
+++ b/lib/feature/receipe/presentation/info/recipe_info_screen.dart
@@ -1,184 +1,151 @@
 import 'package:flutter/material.dart';
 import 'package:recipe_app/core/modules/state/state_handling.dart';
-import 'package:recipe_app/core/presentation/pages/base_screen.dart';
 import 'package:recipe_app/core/presentation/widgets/tab/app_tabbar.dart';
 import 'package:recipe_app/core/style/app_color.dart';
 import 'package:recipe_app/core/style/app_textstyle.dart';
-import 'package:recipe_app/feature/receipe/presentation/info/recipe_info_view_model.dart';
+import 'package:recipe_app/feature/receipe/presentation/info/recipe_info_action.dart';
+import 'package:recipe_app/feature/receipe/presentation/info/recipe_info_state.dart';
 import 'package:recipe_app/feature/receipe/presentation/widgets/follow_button.dart';
 import 'package:recipe_app/feature/receipe/presentation/widgets/ingredient_item.dart';
 import 'package:recipe_app/feature/receipe/presentation/widgets/recipe_card.dart';
 
-class RecipeInfoScreen extends StatefulWidget {
-  final int id;
-  final RecipeInfoViewModel viewModel;
+class RecipeInfoScreen extends StatelessWidget {
+  final RecipeInfoState state;
+  final void Function(RecipeInfoAction action) onAction;
   const RecipeInfoScreen({
-    required this.id,
-    required this.viewModel,
+    required this.state,
+    required this.onAction,
     super.key,
   });
 
   @override
-  State<RecipeInfoScreen> createState() => _RecipeInfoScreenState();
-
-  static const List<String> _tabs = ['Ingredient', 'Procedure'];
-}
-
-class _RecipeInfoScreenState extends State<RecipeInfoScreen> {
-  @override
-  void initState() {
-    widget.viewModel.getRecipeInfo(widget.id);
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return DefaultTabController(
-      length: 2,
-      child: BaseScreen(
-        appBar: AppBar(
-          backgroundColor: AppColor.white,
-          actions: const [Icon(Icons.more_horiz), SizedBox(width: 20)],
-        ),
-        child: ListenableBuilder(
-          listenable: widget.viewModel..getRecipeInfo(widget.id),
-          builder: (context, child) {
-            final recipe = widget.viewModel.state.recipe;
-            if (recipe == null) {
-              return const Center(child: CircularProgressIndicator());
-            }
-            return StateHandling(
-              widget.viewModel.state.state,
-              complete: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 30),
-                child: Column(
-                  children: [
-                    RecipeCard.toInfo(recipe: recipe, bookmarkTap: () {}),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 10),
-                      child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Flexible(
-                            flex: 2,
-                            child: Text(
-                              recipe.name,
-                              style: AppTextStyle.normalBold,
-                            ),
-                          ),
-                          Flexible(
-                            flex: 1,
-                            child: Text(
-                              '13k Riviews',
-                              style: AppTextStyle.normalRegular.copyWith(
-                                color: AppColor.grey3,
-                              ),
-                            ),
-                          ),
-                        ],
+    if (state.recipe == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    return StateHandling(
+      state.state,
+      complete: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 30),
+        child: Column(
+          children: [
+            RecipeCard.toInfo(recipe: state.recipe!, bookmarkTap: () {}),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 10),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Flexible(
+                    flex: 2,
+                    child: Text(
+                      state.recipe!.name,
+                      style: AppTextStyle.normalBold,
+                    ),
+                  ),
+                  Flexible(
+                    flex: 1,
+                    child: Text(
+                      '13k Riviews',
+                      style: AppTextStyle.normalRegular.copyWith(
+                        color: AppColor.grey3,
                       ),
                     ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 10),
-                      child: Row(
-                        children: [
-                          Container(
-                            decoration: const BoxDecoration(
-                              shape: BoxShape.circle,
-                            ),
-                            child: Image.network(
-                              width: 40,
-                              height: 40,
-                              'https://i.pinimg.com/736x/19/72/24/197224dd3c41fc7ad6bef54cc6715209.jpg',
-                            ),
-                          ),
-                          const SizedBox(width: 10),
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  recipe.chef,
-                                  style: AppTextStyle.smallBold,
-                                ),
-                                Row(
-                                  children: [
-                                    const Icon(
-                                      Icons.location_on_outlined,
-                                      color: AppColor.primary100,
-                                    ),
-                                    Text(
-                                      'Laura wilson',
-                                      style: AppTextStyle.smallerRegular
-                                          .copyWith(color: AppColor.grey3),
-                                    ),
-                                  ],
-                                ),
-                              ],
-                            ),
-                          ),
-                          FollowButton(onTap: () {}),
-                        ],
-                      ),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 10),
+              child: Row(
+                children: [
+                  Container(
+                    decoration: const BoxDecoration(shape: BoxShape.circle),
+                    child: Image.network(
+                      width: 40,
+                      height: 40,
+                      'https://i.pinimg.com/736x/19/72/24/197224dd3c41fc7ad6bef54cc6715209.jpg',
                     ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 20),
-                      child: AppTabBar(
-                        tabs: RecipeInfoScreen._tabs,
-                        onValueChange: (val) {},
-                      ),
-                    ),
-                    const SizedBox(height: 22),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
+                        Text(state.recipe!.chef, style: AppTextStyle.smallBold),
                         Row(
                           children: [
                             const Icon(
-                              Icons.room_service_outlined,
-                              color: AppColor.grey3,
+                              Icons.location_on_outlined,
+                              color: AppColor.primary100,
                             ),
                             Text(
-                              '1 serve',
+                              'Laura wilson',
                               style: AppTextStyle.smallerRegular.copyWith(
                                 color: AppColor.grey3,
                               ),
                             ),
                           ],
                         ),
-                        Text(
-                          '${recipe.ingredients.length} items',
-                          style: AppTextStyle.smallerRegular.copyWith(
-                            color: AppColor.grey3,
-                          ),
-                        ),
                       ],
                     ),
-                    const SizedBox(height: 20),
-                    Expanded(
-                      child: ListView.separated(
-                        itemCount: recipe.ingredients.length,
-                        itemBuilder: (context, index) {
-                          final ingredient = recipe.ingredients[index];
-                          return IngredientItem(
-                            imgUrl: ingredient.ingredient.image,
-                            name: ingredient.ingredient.name,
-                            weight: ingredient.amount,
-                          );
-                        },
-                        separatorBuilder: (context, index) {
-                          return const SizedBox(height: 10);
-                        },
+                  ),
+                  FollowButton(onTap: () {}),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 20),
+              child: AppTabBar(tabs: _tabs, onValueChange: (val) {}),
+            ),
+            const SizedBox(height: 22),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Row(
+                  children: [
+                    const Icon(
+                      Icons.room_service_outlined,
+                      color: AppColor.grey3,
+                    ),
+                    Text(
+                      '1 serve',
+                      style: AppTextStyle.smallerRegular.copyWith(
+                        color: AppColor.grey3,
                       ),
                     ),
                   ],
                 ),
+                Text(
+                  '${state.recipe!.ingredients.length} items',
+                  style: AppTextStyle.smallerRegular.copyWith(
+                    color: AppColor.grey3,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+            Expanded(
+              child: ListView.separated(
+                itemCount: state.recipe!.ingredients.length,
+                itemBuilder: (context, index) {
+                  final ingredient = state.recipe!.ingredients[index];
+                  return IngredientItem(
+                    imgUrl: ingredient.ingredient.image,
+                    name: ingredient.ingredient.name,
+                    weight: ingredient.amount,
+                  );
+                },
+                separatorBuilder: (context, index) {
+                  return const SizedBox(height: 10);
+                },
               ),
-            );
-          },
+            ),
+          ],
         ),
       ),
     );
   }
+
+  static const List<String> _tabs = ['Ingredient', 'Procedure'];
 }

--- a/lib/feature/receipe/presentation/info/recipe_info_screen_root.dart
+++ b/lib/feature/receipe/presentation/info/recipe_info_screen_root.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:recipe_app/core/presentation/pages/base_screen.dart';
+import 'package:recipe_app/core/style/app_color.dart';
+import 'package:recipe_app/feature/receipe/presentation/info/recipe_info_action.dart';
+import 'package:recipe_app/feature/receipe/presentation/info/recipe_info_screen.dart';
+import 'package:recipe_app/feature/receipe/presentation/info/recipe_info_view_model.dart';
+
+class RecipeInfoScreenRoot extends StatefulWidget {
+  final int id;
+  final RecipeInfoViewModel viewModel;
+  const RecipeInfoScreenRoot({
+    required this.id,
+    required this.viewModel,
+    super.key,
+  });
+
+  @override
+  State<RecipeInfoScreenRoot> createState() => _RecipeInfoScreenRootState();
+}
+
+class _RecipeInfoScreenRootState extends State<RecipeInfoScreenRoot> {
+  @override
+  void initState() {
+    widget.viewModel.onAction(RecipeInfoAction.getRecipeInfo(widget.id));
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 2,
+      child: BaseScreen(
+        appBar: AppBar(
+          backgroundColor: AppColor.white,
+          actions: const [Icon(Icons.more_horiz), SizedBox(width: 20)],
+        ),
+        child: ListenableBuilder(
+          listenable: widget.viewModel,
+          builder: (context, child) {
+            return RecipeInfoScreen(
+              state: widget.viewModel.state,
+              onAction: widget.viewModel.onAction,
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/feature/receipe/presentation/info/recipe_info_view_model.dart
+++ b/lib/feature/receipe/presentation/info/recipe_info_view_model.dart
@@ -3,6 +3,7 @@ import 'package:recipe_app/core/enum/state_enum.dart';
 import 'package:recipe_app/core/modules/error_handling/result.dart';
 import 'package:recipe_app/feature/receipe/domain/model/recipe.dart';
 import 'package:recipe_app/feature/receipe/domain/use_case/info/get_recipe_info_use_case.dart';
+import 'package:recipe_app/feature/receipe/presentation/info/recipe_info_action.dart';
 import 'package:recipe_app/feature/receipe/presentation/info/recipe_info_state.dart';
 
 class RecipeInfoViewModel with ChangeNotifier {
@@ -13,7 +14,14 @@ class RecipeInfoViewModel with ChangeNotifier {
   RecipeInfoState _state = RecipeInfoState();
   RecipeInfoState get state => _state;
 
-  Future<void> getRecipeInfo(int id) async {
+  void onAction(RecipeInfoAction action) {
+    switch (action) {
+      case GetRecipeInfo():
+        _getRecipeInfo(action.id);
+    }
+  }
+
+  Future<void> _getRecipeInfo(int id) async {
     final result = await _getRecipeInfoUseCase.execute(id);
     switch (result) {
       case Success<Recipe>():

--- a/lib/feature/receipe/presentation/saved_recipes/saved_recipes_action.dart
+++ b/lib/feature/receipe/presentation/saved_recipes/saved_recipes_action.dart
@@ -1,0 +1,13 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'saved_recipes_action.freezed.dart';
+part 'saved_recipes_action.g.dart';
+
+@freezed
+sealed class SavedRecipesAction with _$SavedRecipesAction {
+  const factory SavedRecipesAction.fetchRecipes() = FetchRecipes;
+  const factory SavedRecipesAction.bookmarkRecipe(int id) = BookmarkRecipe;
+
+  factory SavedRecipesAction.fromJson(Map<String, dynamic> json) =>
+      _$SavedRecipesActionFromJson(json);
+}

--- a/lib/feature/receipe/presentation/saved_recipes/saved_recipes_action.freezed.dart
+++ b/lib/feature/receipe/presentation/saved_recipes/saved_recipes_action.freezed.dart
@@ -1,0 +1,183 @@
+// dart format width=80
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'saved_recipes_action.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+SavedRecipesAction _$SavedRecipesActionFromJson(
+  Map<String, dynamic> json
+) {
+        switch (json['runtimeType']) {
+                  case 'fetchRecipes':
+          return FetchRecipes.fromJson(
+            json
+          );
+                case 'bookmarkRecipe':
+          return BookmarkRecipe.fromJson(
+            json
+          );
+        
+          default:
+            throw CheckedFromJsonException(
+  json,
+  'runtimeType',
+  'SavedRecipesAction',
+  'Invalid union type "${json['runtimeType']}"!'
+);
+        }
+      
+}
+
+/// @nodoc
+mixin _$SavedRecipesAction {
+
+
+
+  /// Serializes this SavedRecipesAction to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SavedRecipesAction);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'SavedRecipesAction()';
+}
+
+
+}
+
+/// @nodoc
+class $SavedRecipesActionCopyWith<$Res>  {
+$SavedRecipesActionCopyWith(SavedRecipesAction _, $Res Function(SavedRecipesAction) __);
+}
+
+
+/// @nodoc
+@JsonSerializable()
+
+class FetchRecipes implements SavedRecipesAction {
+  const FetchRecipes({final  String? $type}): $type = $type ?? 'fetchRecipes';
+  factory FetchRecipes.fromJson(Map<String, dynamic> json) => _$FetchRecipesFromJson(json);
+
+
+
+@JsonKey(name: 'runtimeType')
+final String $type;
+
+
+
+@override
+Map<String, dynamic> toJson() {
+  return _$FetchRecipesToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is FetchRecipes);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'SavedRecipesAction.fetchRecipes()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class BookmarkRecipe implements SavedRecipesAction {
+  const BookmarkRecipe(this.id, {final  String? $type}): $type = $type ?? 'bookmarkRecipe';
+  factory BookmarkRecipe.fromJson(Map<String, dynamic> json) => _$BookmarkRecipeFromJson(json);
+
+ final  int id;
+
+@JsonKey(name: 'runtimeType')
+final String $type;
+
+
+/// Create a copy of SavedRecipesAction
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$BookmarkRecipeCopyWith<BookmarkRecipe> get copyWith => _$BookmarkRecipeCopyWithImpl<BookmarkRecipe>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$BookmarkRecipeToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is BookmarkRecipe&&(identical(other.id, id) || other.id == id));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id);
+
+@override
+String toString() {
+  return 'SavedRecipesAction.bookmarkRecipe(id: $id)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $BookmarkRecipeCopyWith<$Res> implements $SavedRecipesActionCopyWith<$Res> {
+  factory $BookmarkRecipeCopyWith(BookmarkRecipe value, $Res Function(BookmarkRecipe) _then) = _$BookmarkRecipeCopyWithImpl;
+@useResult
+$Res call({
+ int id
+});
+
+
+
+
+}
+/// @nodoc
+class _$BookmarkRecipeCopyWithImpl<$Res>
+    implements $BookmarkRecipeCopyWith<$Res> {
+  _$BookmarkRecipeCopyWithImpl(this._self, this._then);
+
+  final BookmarkRecipe _self;
+  final $Res Function(BookmarkRecipe) _then;
+
+/// Create a copy of SavedRecipesAction
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? id = null,}) {
+  return _then(BookmarkRecipe(
+null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/feature/receipe/presentation/saved_recipes/saved_recipes_action.g.dart
+++ b/lib/feature/receipe/presentation/saved_recipes/saved_recipes_action.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'saved_recipes_action.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+FetchRecipes _$FetchRecipesFromJson(Map<String, dynamic> json) =>
+    FetchRecipes($type: json['runtimeType'] as String?);
+
+Map<String, dynamic> _$FetchRecipesToJson(FetchRecipes instance) =>
+    <String, dynamic>{'runtimeType': instance.$type};
+
+BookmarkRecipe _$BookmarkRecipeFromJson(Map<String, dynamic> json) =>
+    BookmarkRecipe(
+      (json['id'] as num).toInt(),
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$BookmarkRecipeToJson(BookmarkRecipe instance) =>
+    <String, dynamic>{'id': instance.id, 'runtimeType': instance.$type};

--- a/lib/feature/receipe/presentation/saved_recipes/saved_recipes_screen.dart
+++ b/lib/feature/receipe/presentation/saved_recipes/saved_recipes_screen.dart
@@ -1,54 +1,43 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:recipe_app/core/modules/state/state_handling.dart';
-import 'package:recipe_app/core/style/app_color.dart';
-import 'package:recipe_app/core/presentation/pages/base_screen.dart';
-import 'package:recipe_app/feature/receipe/presentation/saved_recipes/saved_recipes_view_model.dart';
+import 'package:recipe_app/feature/receipe/presentation/saved_recipes/saved_recipes_action.dart';
+import 'package:recipe_app/feature/receipe/presentation/saved_recipes/saved_recipes_state.dart';
 import 'package:recipe_app/feature/receipe/presentation/widgets/recipe_card.dart';
 
 class SavedRecipesScreen extends StatelessWidget {
-  final SavedRecipesViewModel viewModel;
-  const SavedRecipesScreen(this.viewModel, {super.key});
+  final SavedRecipesState state;
+  final void Function(SavedRecipesAction action) onAction;
+  const SavedRecipesScreen({
+    required this.onAction,
+    required this.state,
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return BaseScreen(
-      appBar: AppBar(
-        title: const Text('Saved recipes'),
-        backgroundColor: AppColor.white,
-      ),
-      child: ListenableBuilder(
-        listenable: viewModel..fetchRecipes(),
-        builder: (context, child) {
-          final viewState = viewModel.state.viewState;
-          final recipes = viewModel.state.data;
-
-          return StateHandling(
-            viewState,
-            complete: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 30),
-              child: ListView.separated(
-                itemCount: recipes.length,
-                itemBuilder: (context, index) {
-                  final recipe = recipes[index];
-                  final id = recipe.id;
-                  return RecipeCard.fromModel(
-                    recipe: recipe,
-                    bookmarkTap: () => viewModel.bookmarkRecipe(id),
-                    cardTap:
-                        () => context.pushNamed(
-                          'info',
-                          pathParameters: {'id': '$id'},
-                        ),
-                  );
-                },
-                separatorBuilder: (context, index) {
-                  return const SizedBox(height: 20);
-                },
-              ),
-            ),
-          );
-        },
+    return StateHandling(
+      state.viewState,
+      complete: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 30),
+        child: ListView.separated(
+          itemCount: state.data.length,
+          itemBuilder: (context, index) {
+            final recipe = state.data[index];
+            final id = recipe.id;
+            return RecipeCard.fromModel(
+              recipe: recipe,
+              bookmarkTap:
+                  () => onAction(SavedRecipesAction.bookmarkRecipe(id)),
+              cardTap:
+                  () =>
+                      context.pushNamed('info', pathParameters: {'id': '$id'}),
+            );
+          },
+          separatorBuilder: (context, index) {
+            return const SizedBox(height: 20);
+          },
+        ),
       ),
     );
   }

--- a/lib/feature/receipe/presentation/saved_recipes/saved_recipes_screen_root.dart
+++ b/lib/feature/receipe/presentation/saved_recipes/saved_recipes_screen_root.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:recipe_app/core/style/app_color.dart';
+import 'package:recipe_app/core/presentation/pages/base_screen.dart';
+import 'package:recipe_app/feature/receipe/presentation/saved_recipes/saved_recipes_screen.dart';
+import 'package:recipe_app/feature/receipe/presentation/saved_recipes/saved_recipes_view_model.dart';
+
+class SavedRecipesScreenRoot extends StatelessWidget {
+  final SavedRecipesViewModel viewModel;
+  const SavedRecipesScreenRoot(this.viewModel, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScreen(
+      appBar: AppBar(
+        title: const Text('Saved recipes'),
+        backgroundColor: AppColor.white,
+      ),
+      child: ListenableBuilder(
+        listenable: viewModel,
+        builder: (context, child) {
+          final state = viewModel.state;
+
+          return SavedRecipesScreen(onAction: viewModel.onAction, state: state);
+        },
+      ),
+    );
+  }
+}

--- a/lib/feature/receipe/presentation/saved_recipes/saved_recipes_screen_root.dart
+++ b/lib/feature/receipe/presentation/saved_recipes/saved_recipes_screen_root.dart
@@ -1,12 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:recipe_app/core/style/app_color.dart';
 import 'package:recipe_app/core/presentation/pages/base_screen.dart';
+import 'package:recipe_app/feature/receipe/presentation/saved_recipes/saved_recipes_action.dart';
 import 'package:recipe_app/feature/receipe/presentation/saved_recipes/saved_recipes_screen.dart';
 import 'package:recipe_app/feature/receipe/presentation/saved_recipes/saved_recipes_view_model.dart';
 
-class SavedRecipesScreenRoot extends StatelessWidget {
+class SavedRecipesScreenRoot extends StatefulWidget {
   final SavedRecipesViewModel viewModel;
   const SavedRecipesScreenRoot(this.viewModel, {super.key});
+
+  @override
+  State<SavedRecipesScreenRoot> createState() => _SavedRecipesScreenRootState();
+}
+
+class _SavedRecipesScreenRootState extends State<SavedRecipesScreenRoot> {
+  @override
+  void initState() {
+    widget.viewModel.onAction(const SavedRecipesAction.fetchRecipes());
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -16,11 +28,14 @@ class SavedRecipesScreenRoot extends StatelessWidget {
         backgroundColor: AppColor.white,
       ),
       child: ListenableBuilder(
-        listenable: viewModel,
+        listenable: widget.viewModel,
         builder: (context, child) {
-          final state = viewModel.state;
+          final state = widget.viewModel.state;
 
-          return SavedRecipesScreen(onAction: viewModel.onAction, state: state);
+          return SavedRecipesScreen(
+            onAction: widget.viewModel.onAction,
+            state: state,
+          );
         },
       ),
     );

--- a/lib/feature/receipe/presentation/saved_recipes/saved_recipes_view_model.dart
+++ b/lib/feature/receipe/presentation/saved_recipes/saved_recipes_view_model.dart
@@ -4,6 +4,7 @@ import 'package:recipe_app/core/modules/error_handling/result.dart';
 import 'package:recipe_app/feature/receipe/domain/model/recipe.dart';
 import 'package:recipe_app/feature/receipe/domain/use_case/saved_recipes/bookmark_recipes_use_case.dart';
 import 'package:recipe_app/feature/receipe/domain/use_case/saved_recipes/get_saved_recipes_use_case.dart';
+import 'package:recipe_app/feature/receipe/presentation/saved_recipes/saved_recipes_action.dart';
 import 'package:recipe_app/feature/receipe/presentation/saved_recipes/saved_recipes_state.dart';
 
 class SavedRecipesViewModel with ChangeNotifier {
@@ -19,7 +20,16 @@ class SavedRecipesViewModel with ChangeNotifier {
   SavedRecipesState _state = const SavedRecipesState();
   SavedRecipesState get state => _state;
 
-  void fetchRecipes() async {
+  void onAction(SavedRecipesAction action) {
+    switch (action) {
+      case FetchRecipes():
+        _fetchRecipes();
+      case BookmarkRecipe():
+        _bookmarkRecipe(action.id);
+    }
+  }
+
+  void _fetchRecipes() async {
     _state = state.copyWith(viewState: ViewState.loading);
     notifyListeners();
     final resp = await _getSavedRecipesUseCase.excute();
@@ -32,8 +42,7 @@ class SavedRecipesViewModel with ChangeNotifier {
     notifyListeners();
   }
 
-  void bookmarkRecipe(int id) async {
-    print('id: $id');
+  void _bookmarkRecipe(int id) async {
     final result = await _bookmarkRecipesUseCase.excute(id);
     switch (result) {
       case Success<bool>():

--- a/lib/feature/receipe/presentation/search_recipes/search_action.dart
+++ b/lib/feature/receipe/presentation/search_recipes/search_action.dart
@@ -1,0 +1,35 @@
+sealed class SearchAction {
+  const factory SearchAction.fetchSearchData() = FetchSearchData;
+  const factory SearchAction.filterData({
+    required String time,
+    required int rate,
+    required String category,
+  }) = FilterData;
+  const factory SearchAction.searchData(String text) = SearchData;
+  const factory SearchAction.getRecentSearchText() = GetRecentSearchText;
+}
+
+class FetchSearchData implements SearchAction {
+  const FetchSearchData();
+}
+
+class FilterData implements SearchAction {
+  final String time;
+  final int rate;
+  final String category;
+
+  const FilterData({
+    required this.time,
+    required this.rate,
+    required this.category,
+  });
+}
+
+class SearchData implements SearchAction {
+  final String text;
+  const SearchData(this.text);
+}
+
+class GetRecentSearchText implements SearchAction {
+  const GetRecentSearchText();
+}

--- a/lib/feature/receipe/presentation/search_recipes/search_screen.dart
+++ b/lib/feature/receipe/presentation/search_recipes/search_screen.dart
@@ -2,17 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:recipe_app/core/modules/state/state_handling.dart';
 import 'package:recipe_app/core/style/app_color.dart';
 import 'package:recipe_app/core/style/app_textstyle.dart';
-import 'package:recipe_app/core/presentation/pages/base_screen.dart';
 import 'package:recipe_app/feature/receipe/presentation/filter_modal/filter_search_screen.dart';
 import 'package:recipe_app/feature/receipe/presentation/filter_modal/filter_search_view_model.dart';
-import 'package:recipe_app/feature/receipe/presentation/search_recipes/search_view_model.dart';
+import 'package:recipe_app/feature/receipe/presentation/search_recipes/search_action.dart';
+import 'package:recipe_app/feature/receipe/presentation/search_recipes/search_state.dart';
 import 'package:recipe_app/core/presentation/widgets/textfield/app_textfield.dart';
 import 'package:recipe_app/feature/receipe/presentation/widgets/filter_search_button.dart';
 import 'package:recipe_app/feature/receipe/presentation/widgets/recipe_card.dart';
 
 class SearchScreen extends StatefulWidget {
-  final SearchViewModel viewModel;
-  const SearchScreen(this.viewModel, {super.key});
+  final SearchState state;
+  final void Function(SearchAction action) onAction;
+  const SearchScreen({required this.state, required this.onAction, super.key});
 
   @override
   State<SearchScreen> createState() => _SearchScreenState();
@@ -22,149 +23,122 @@ class _SearchScreenState extends State<SearchScreen> {
   final TextEditingController _controller = TextEditingController();
 
   @override
-  void initState() {
-    widget.viewModel.fetchSearchData();
-    widget.viewModel.getRecentSearchText();
-    super.initState();
-  }
-
-  @override
   void dispose() {
     _controller.dispose();
+    widget.onAction(const SearchAction.fetchSearchData());
+    widget.onAction(const SearchAction.getRecentSearchText());
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    final filterSearchViewModel = FilterSearchViewModel(widget.viewModel);
-    return BaseScreen(
-      appBar: AppBar(
-        backgroundColor: AppColor.white,
-        title: const Text('Search recipes'),
-      ),
-      child: ListenableBuilder(
-        listenable: widget.viewModel,
-        builder: (context, child) {
-          final state = widget.viewModel.state;
-          final isChangeUI = widget.viewModel.isChangeUI;
-          final viewState = state.viewState;
-          final recipes = state.data;
-
-          return StateHandling(
-            viewState,
-            complete: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 20),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const SizedBox(height: 12),
-                  Row(
-                    children: [
-                      Expanded(
-                        child: AppTextField(
-                          prefixIcon: const Icon(
-                            Icons.search,
-                            color: AppColor.grey4,
-                          ),
-                          onChanged: (val) {
-                            widget.viewModel.searchData(val);
-                          },
-                          borderColor: AppColor.grey4,
-                          textColor: AppColor.grey4,
-                          contentPadding: const EdgeInsets.all(8),
-                          controller: _controller,
-                          hintText: 'Search recipe',
-                        ),
-                      ),
-                      const SizedBox(width: 20),
-                      FilterSearchButton(() {
-                        filterSearchViewModel.resetData();
-                        showModalBottomSheet(
-                          context: context,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(50),
-                          ),
-                          builder: (context) {
-                            return FilterSearch(filterSearchViewModel);
-                          },
-                        );
-                      }),
-                    ],
+    return StateHandling(
+      widget.state.viewState,
+      complete: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: AppTextField(
+                    prefixIcon: const Icon(Icons.search, color: AppColor.grey4),
+                    onChanged: (val) {
+                      widget.onAction(SearchAction.searchData(val));
+                    },
+                    borderColor: AppColor.grey4,
+                    textColor: AppColor.grey4,
+                    contentPadding: const EdgeInsets.all(8),
+                    controller: _controller,
+                    hintText: 'Search recipe',
                   ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                    child: Wrap(
-                      spacing: 8,
-                      runSpacing: 8,
-                      children:
-                          widget.viewModel.state.recentSearchText
-                              .map(
-                                (e) => Container(
-                                  padding: const EdgeInsets.symmetric(
-                                    vertical: 4,
-                                    horizontal: 4,
-                                  ),
-                                  decoration: BoxDecoration(
-                                    border: Border.all(),
-                                    borderRadius: BorderRadius.circular(10),
-                                  ),
-                                  child: Text(
-                                    e,
-                                    style: AppTextStyle.smallRegular,
-                                  ),
-                                ),
-                              )
-                              .toList(),
+                ),
+                const SizedBox(width: 20),
+                FilterSearchButton(() {
+                  showModalBottomSheet(
+                    context: context,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(50),
                     ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 20),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text(
-                          isChangeUI ? 'Search Result' : 'Recent Search',
-                          style: AppTextStyle.normalBold,
-                        ),
-                        if (isChangeUI)
-                          Text(
-                            '${recipes.length} results',
-                            style: AppTextStyle.smallerRegular.copyWith(
-                              color: AppColor.grey3,
+                    builder: (context) {
+                      return FilterSearch(FilterSearchViewModel());
+                    },
+                  );
+                }),
+              ],
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 12),
+              child: Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children:
+                    widget.state.recentSearchText
+                        .map(
+                          (e) => Container(
+                            padding: const EdgeInsets.symmetric(
+                              vertical: 4,
+                              horizontal: 4,
                             ),
+                            decoration: BoxDecoration(
+                              border: Border.all(),
+                              borderRadius: BorderRadius.circular(10),
+                            ),
+                            child: Text(e, style: AppTextStyle.smallRegular),
                           ),
-                      ],
-                    ),
+                        )
+                        .toList(),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(bottom: 20),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    _isChangeUI ? 'Search Result' : 'Recent Search',
+                    style: AppTextStyle.normalBold,
                   ),
-                  Expanded(
-                    child: GridView.builder(
-                      shrinkWrap: true,
-                      gridDelegate:
-                          const SliverGridDelegateWithFixedCrossAxisCount(
-                            crossAxisCount: 2,
-                            mainAxisSpacing: 15,
-                            crossAxisSpacing: 15,
-                          ),
-                      itemCount: recipes.length,
-                      itemBuilder: (context, index) {
-                        final recipe = recipes[index];
-                        return RecipeCard(
-                          recipeId: recipe.id,
-                          imgUrl: recipe.image,
-                          title: recipe.name,
-                          owner: recipe.chef,
-                          starCount: recipe.rating,
-                          bookmarkTap: () {},
-                        );
-                      },
+                  if (_isChangeUI)
+                    Text(
+                      '${widget.state.data.length} results',
+                      style: AppTextStyle.smallerRegular.copyWith(
+                        color: AppColor.grey3,
+                      ),
                     ),
-                  ),
                 ],
               ),
             ),
-          );
-        },
+            Expanded(
+              child: GridView.builder(
+                shrinkWrap: true,
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 2,
+                  mainAxisSpacing: 15,
+                  crossAxisSpacing: 15,
+                ),
+                itemCount: widget.state.data.length,
+                itemBuilder: (context, index) {
+                  final recipe = widget.state.data[index];
+                  return RecipeCard(
+                    recipeId: recipe.id,
+                    imgUrl: recipe.image,
+                    title: recipe.name,
+                    owner: recipe.chef,
+                    starCount: recipe.rating,
+                    bookmarkTap: () {},
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
+
+  bool get _isChangeUI =>
+      widget.state.isFiltered || widget.state.searchText.isNotEmpty;
 }

--- a/lib/feature/receipe/presentation/search_recipes/search_screen_root.dart
+++ b/lib/feature/receipe/presentation/search_recipes/search_screen_root.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:recipe_app/core/presentation/pages/base_screen.dart';
+import 'package:recipe_app/core/style/app_color.dart';
+import 'package:recipe_app/feature/receipe/presentation/search_recipes/search_screen.dart';
+import 'package:recipe_app/feature/receipe/presentation/search_recipes/search_view_model.dart';
+
+class SearchScreenRoot extends StatelessWidget {
+  final SearchViewModel viewModel;
+  const SearchScreenRoot(this.viewModel, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScreen(
+      appBar: AppBar(
+        backgroundColor: AppColor.white,
+        title: const Text('Search recipes'),
+      ),
+      child: ListenableBuilder(
+        listenable: viewModel,
+        builder: (context, child) {
+          return SearchScreen(
+            state: viewModel.state,
+            onAction: viewModel.onAction,
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/feature/receipe/presentation/search_recipes/search_view_model.dart
+++ b/lib/feature/receipe/presentation/search_recipes/search_view_model.dart
@@ -5,6 +5,7 @@ import 'package:recipe_app/feature/receipe/domain/model/recipe.dart';
 import 'package:recipe_app/feature/receipe/domain/use_case/saved_recipes/get_recent_search_text_use_case.dart';
 import 'package:recipe_app/feature/receipe/domain/use_case/saved_recipes/get_saved_recipes_use_case.dart';
 import 'package:recipe_app/feature/receipe/domain/use_case/saved_recipes/save_recent_search_text_use_case.dart';
+import 'package:recipe_app/feature/receipe/presentation/search_recipes/search_action.dart';
 import 'package:recipe_app/feature/receipe/presentation/search_recipes/search_state.dart';
 
 class SearchViewModel with ChangeNotifier {
@@ -26,7 +27,24 @@ class SearchViewModel with ChangeNotifier {
   // UI 변경 유무 상태값
   bool get isChangeUI => _state.isFiltered || _state.searchText.isNotEmpty;
 
-  void fetchSearchData() async {
+  void onAction(SearchAction action) {
+    switch (action) {
+      case FetchSearchData():
+        _fetchSearchData();
+      case FilterData():
+        _filterData(
+          time: action.time,
+          rate: action.rate,
+          category: action.category,
+        );
+      case SearchData():
+        _searchData(action.text);
+      case GetRecentSearchText():
+        _getRecentSearchText();
+    }
+  }
+
+  void _fetchSearchData() async {
     try {
       _state = state.copyWith(viewState: ViewState.loading);
       notifyListeners();
@@ -47,7 +65,7 @@ class SearchViewModel with ChangeNotifier {
     }
   }
 
-  void filterData({
+  void _filterData({
     required String time,
     required int rate,
     required String category,
@@ -76,7 +94,7 @@ class SearchViewModel with ChangeNotifier {
     notifyListeners();
   }
 
-  void searchData(String text) {
+  void _searchData(String text) {
     _state = state.copyWith(searchText: text);
     // 현재 필터링됐는지 안됐는지에 따라
     // 다르게 기본 베이스 데이터를 설정
@@ -91,12 +109,12 @@ class SearchViewModel with ChangeNotifier {
         data: baseData.where((e) => e.name.contains(text)).toList(),
         viewState: ViewState.complete,
       );
-      saveSearchText(text);
+      _saveSearchText(text);
     }
     notifyListeners();
   }
 
-  void getRecentSearchText() async {
+  void _getRecentSearchText() async {
     final result = await _getRecentSearchTextUseCase.execute();
     switch (result) {
       case Success<List<String>>():
@@ -110,7 +128,7 @@ class SearchViewModel with ChangeNotifier {
     notifyListeners();
   }
 
-  void saveSearchText(String text) async {
+  void _saveSearchText(String text) async {
     final result = await _saveRecentSearchTextUseCase.execute(text);
     switch (result) {
       case Success<List<String>>():

--- a/lib/feature/receipe/presentation/widgets/home_card.dart
+++ b/lib/feature/receipe/presentation/widgets/home_card.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:recipe_app/core/style/app_color.dart';
+import 'package:recipe_app/core/style/app_textstyle.dart';
+import 'package:recipe_app/feature/receipe/domain/model/recipe.dart';
+
+class HomeCard extends StatelessWidget {
+  final Recipe recipe;
+  const HomeCard(this.recipe, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 230,
+      child: Stack(
+        alignment: Alignment.bottomCenter,
+        clipBehavior: Clip.none,
+        children: [
+          Container(
+            height: 170,
+            width: 150,
+            padding: const EdgeInsets.all(10),
+            decoration: BoxDecoration(
+              color: AppColor.grey4,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                Text(
+                  recipe.name,
+                  style: AppTextStyle.smallerBold,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 20),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Time',
+                          style: AppTextStyle.smallRegular.copyWith(
+                            color: AppColor.grey3,
+                          ),
+                        ),
+                        Text(
+                          recipe.time,
+                          style: AppTextStyle.smallerBold.copyWith(
+                            color: AppColor.grey2,
+                          ),
+                        ),
+                      ],
+                    ),
+                    Container(
+                      padding: const EdgeInsets.all(4),
+                      decoration: const BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: AppColor.white,
+                      ),
+                      child: const Icon(
+                        Icons.bookmark_outline,
+                        color: AppColor.primary100,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          Positioned(
+            left: 20,
+            top: 0,
+            child: Container(
+              width: 110,
+              height: 110,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                image: DecorationImage(
+                  image: NetworkImage(recipe.image),
+                  fit: BoxFit.cover,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/unit/recipe_info_test.dart
+++ b/test/unit/recipe_info_test.dart
@@ -9,6 +9,7 @@ import 'package:recipe_app/feature/receipe/domain/model/recipe.dart';
 import 'package:recipe_app/feature/receipe/domain/repository/info/recipe_info_repository.dart';
 import 'package:recipe_app/feature/receipe/data/dto/recipe_dto.dart';
 import 'package:recipe_app/feature/receipe/domain/use_case/info/get_recipe_info_use_case.dart';
+import 'package:recipe_app/feature/receipe/presentation/info/recipe_info_action.dart';
 import 'package:recipe_app/feature/receipe/presentation/info/recipe_info_view_model.dart';
 
 void main() {
@@ -33,7 +34,7 @@ void main() {
       final RecipeInfoViewModel viewModel = RecipeInfoViewModel(
         GetRecipeInfoUseCase(repository),
       );
-      await viewModel.getRecipeInfo(1);
+      viewModel.onAction(const RecipeInfoAction.getRecipeInfo(1));
       expect(viewModel.state.recipe, equals(isA<Recipe>()));
       expect(viewModel.state.recipe, equals(mock.toRecipe()));
     });


### PR DESCRIPTION
# 250422_13_임명우

## 📝 과제 정보

- **교육 주제**: 고급 상태관리 기법

## ✅ 구현 내용

- MVI 패턴 적용
- 뷰가 테스트 가능하도록 수정

## 📋 체크리스트

- [O] 코드 정리
- [x] Test 코드 작성
- [O] 과제 구현

## 🔍 구현 방법

- screen / screen root 나누기
- 각 뷰마다 사용되는 action을 따로 정의하여 관리

## 📷 실행 결과

<img width=30% src='https://github.com/user-attachments/assets/3af1aae6-5b2f-4ae0-9b03-24a59c058b38'>
<img width=30% src='https://github.com/user-attachments/assets/e5f43114-c2ee-4028-9a91-a3dd3ea29393'>
<img width=30% src='https://github.com/user-attachments/assets/a42a0af7-dcfc-42f8-b771-6310b4652cdc'>

## 🚨 어려웠던 점

처음 보는 패턴이라 익숙치않았지만 이전에 했던 과정들이 확실히 도움이 된다..

## 💡 배운 점

- MVI 패턴
- 뷰가 테스트 가능하도록 설정하기

## 🔄 자체 평가 & 회고

튜토리얼 끝! 남은 기간도 화이팅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 홈, 레시피 상세, 저장된 레시피, 검색 등 주요 화면에 대한 Root 위젯 및 상태/액션 기반 구조 도입
  - 홈 화면에서 카테고리별 필터 및 레시피 카드 UI 추가
  - 레시피 상세, 저장된 레시피, 검색 등에서 액션 객체를 통한 이벤트 처리 방식 적용

- **버그 수정**
  - 레시피 검색 결과에 "bookmarkStatus" 필드 추가로 북마크 상태 표시 개선

- **리팩터링**
  - ViewModel 직접 호출 방식에서 액션 기반 이벤트 처리로 구조 개선
  - 주요 화면을 상태와 액션을 명시적으로 전달받는 프레젠테이션 위젯으로 변경

- **테스트**
  - 레시피 상세 테스트에서 액션 기반 호출 방식으로 수정

- **기타**
  - 의존성 주입 및 라우팅 구조 업데이트, 불필요한 내부 상태 관리 코드 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->