### PR TITLE
230422_16_김옥현

### DIFF
--- a/lib/core/di/di_setup.dart
+++ b/lib/core/di/di_setup.dart
@@ -78,8 +78,10 @@ void diSetup() {
 
   // ViewModel
   getIt.registerFactory<HomeViewModel>(
-    () =>
-        HomeViewModel(getSavedRecipesUseCase: getIt<GetSavedRecipesUseCase>()),
+    () => HomeViewModel(
+      getSavedRecipesUseCase: getIt<GetSavedRecipesUseCase>(),
+      toggleFavoriteUseCase: getIt<ToggleFavoriteUseCase>(),
+    ),
   );
 
   getIt.registerFactory<SplashViewModel>(

--- a/lib/core/di/di_setup.dart
+++ b/lib/core/di/di_setup.dart
@@ -17,6 +17,7 @@ import 'package:recipe_app/domain/use_case/get_saved_recipes_use_case.dart';
 import 'package:recipe_app/domain/use_case/save_recent_recipes_use_case.dart';
 import 'package:recipe_app/domain/use_case/throw_when_settings_info_use_case.dart';
 import 'package:recipe_app/domain/use_case/toggle_favorite_use_case.dart';
+import 'package:recipe_app/presentation/home/home_view_model.dart';
 import 'package:recipe_app/presentation/ingredient/ingredient_state.dart';
 import 'package:recipe_app/presentation/ingredient/ingredient_view_model.dart';
 import 'package:recipe_app/presentation/saved_recipe/saved_recipes_view_model.dart';
@@ -34,7 +35,10 @@ void diSetup() {
 
   // Repository
   getIt.registerSingleton<RecipeRepository>(
-    RecipeRepositoryImpl(recipeDataSource: getIt(), fileDataSource: getIt<FileDataSource>()),
+    RecipeRepositoryImpl(
+      recipeDataSource: getIt(),
+      fileDataSource: getIt<FileDataSource>(),
+    ),
   );
   getIt.registerSingleton<BookmarkRepository>(
     BookmarkRepositoryImpl(recipeDataSource: getIt()),
@@ -73,6 +77,8 @@ void diSetup() {
   );
 
   // ViewModel
+  getIt.registerFactory<HomeViewModel>(() => HomeViewModel());
+
   getIt.registerFactory<SplashViewModel>(
     () => SplashViewModel(
       throwWhenSettingsInfoUseCase: getIt<ThrowWhenSettingsInfoUseCase>(),

--- a/lib/core/di/di_setup.dart
+++ b/lib/core/di/di_setup.dart
@@ -77,7 +77,10 @@ void diSetup() {
   );
 
   // ViewModel
-  getIt.registerFactory<HomeViewModel>(() => HomeViewModel());
+  getIt.registerFactory<HomeViewModel>(
+    () =>
+        HomeViewModel(getSavedRecipesUseCase: getIt<GetSavedRecipesUseCase>()),
+  );
 
   getIt.registerFactory<SplashViewModel>(
     () => SplashViewModel(

--- a/lib/core/routing/router.dart
+++ b/lib/core/routing/router.dart
@@ -1,7 +1,8 @@
 import 'package:go_router/go_router.dart';
 import 'package:recipe_app/core/di/di_setup.dart';
 import 'package:recipe_app/core/routing/routes.dart';
-import 'package:recipe_app/presentation/home/home_screen.dart';
+import 'package:recipe_app/presentation/home/home_screen_root.dart';
+import 'package:recipe_app/presentation/home/home_view_model.dart';
 import 'package:recipe_app/presentation/ingredient/ingredient_scene.dart';
 import 'package:recipe_app/presentation/ingredient/ingredient_view_model.dart';
 import 'package:recipe_app/presentation/main/main_screen.dart';
@@ -66,7 +67,7 @@ class AppRouter {
             routes: [
               GoRoute(
                 path: Routes.home,
-                builder: (context, state) => const HomeScreen(),
+                builder: (context, state) => HomeScreenRoot(viewModel: getIt<HomeViewModel>()),
               ),
             ],
           ),

--- a/lib/core/routing/router.dart
+++ b/lib/core/routing/router.dart
@@ -20,7 +20,7 @@ import 'package:recipe_app/presentation/splash_screen/splash_view_model.dart';
 
 class AppRouter {
   static final GoRouter router = GoRouter(
-    initialLocation: Routes.home,
+    initialLocation: Routes.splash,
     routes: [
       GoRoute(
         path: Routes.splash,

--- a/lib/core/routing/router.dart
+++ b/lib/core/routing/router.dart
@@ -19,7 +19,7 @@ import 'package:recipe_app/presentation/splash_screen/splash_view_model.dart';
 
 class AppRouter {
   static final GoRouter router = GoRouter(
-    initialLocation: Routes.splash,
+    initialLocation: Routes.home,
     routes: [
       GoRoute(
         path: Routes.splash,

--- a/lib/core/routing/router.dart
+++ b/lib/core/routing/router.dart
@@ -15,7 +15,7 @@ import 'package:recipe_app/presentation/search_recipes/search_recipes_screen.dar
 import 'package:recipe_app/presentation/search_recipes/search_recipes_view_model.dart';
 import 'package:recipe_app/presentation/sign_in/sign_in_screen.dart';
 import 'package:recipe_app/presentation/sign_up/sign_up_screen.dart';
-import 'package:recipe_app/presentation/splash_screen/splash_screen.dart';
+import 'package:recipe_app/presentation/splash_screen/splash_screen_root.dart';
 import 'package:recipe_app/presentation/splash_screen/splash_view_model.dart';
 
 class AppRouter {
@@ -26,7 +26,7 @@ class AppRouter {
         path: Routes.splash,
         builder:
             (context, state) =>
-                SplashScreen(splashViewModel: getIt<SplashViewModel>()),
+                SplashScreenRoot(viewModel: getIt<SplashViewModel>()),
       ),
 
       GoRoute(path: Routes.signIn, builder: (context, state) => SignInScreen()),
@@ -40,7 +40,9 @@ class AppRouter {
         path: Routes.ingredient,
         builder: (context, state) {
           try {
-            final id = state.pathParameters[RoutesParameters.ingredientRecipeIdParameter]!;
+            final id =
+                state.pathParameters[RoutesParameters
+                    .ingredientRecipeIdParameter]!;
             return IngredientScreen(
               viewModel: getIt<IngredientViewModel>(param1: id),
             );
@@ -67,7 +69,9 @@ class AppRouter {
             routes: [
               GoRoute(
                 path: Routes.home,
-                builder: (context, state) => HomeScreenRoot(viewModel: getIt<HomeViewModel>()),
+                builder:
+                    (context, state) =>
+                        HomeScreenRoot(viewModel: getIt<HomeViewModel>()),
               ),
             ],
           ),

--- a/lib/presentation/components/f_dish_card.dart
+++ b/lib/presentation/components/f_dish_card.dart
@@ -164,19 +164,16 @@ class _FDishCardState extends State<FDishCard> {
         widget.recipe.imageUrl,
         width: 110,
         height: 110,
+        filterQuality: FilterQuality.low,
         fit: BoxFit.cover,
-        loadingBuilder: (context, child, loadingProgress) {
-          if (loadingProgress == null) {
+        frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
+          if (wasSynchronouslyLoaded || frame != null) {
             return child;
           }
-          return Center(
-            child: CircularProgressIndicator(
-              value:
-                  loadingProgress.expectedTotalBytes != null
-                      ? loadingProgress.cumulativeBytesLoaded /
-                          loadingProgress.expectedTotalBytes!
-                      : null,
-            ),
+          return SizedBox(
+            width: 110,
+            height: 110,
+            child: Center(child: CircularProgressIndicator()),
           );
         },
       ),

--- a/lib/presentation/components/f_dish_card.dart
+++ b/lib/presentation/components/f_dish_card.dart
@@ -1,0 +1,185 @@
+import 'package:flutter/material.dart';
+import 'package:recipe_app/domain/model/recipe.dart';
+import 'package:recipe_app/ui/color_styles.dart';
+import 'package:recipe_app/ui/text_styles.dart';
+
+class FDishCard extends StatefulWidget {
+  final Recipe recipe;
+  final void Function(Recipe recipe) onTapFavorite;
+
+  const FDishCard({
+    super.key,
+    required this.recipe,
+    required this.onTapFavorite,
+  });
+
+  @override
+  State<FDishCard> createState() => _FDishCardState();
+}
+
+class _FDishCardState extends State<FDishCard> {
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 231,
+      width: 150,
+      child: Stack(
+        alignment: Alignment.topCenter,
+        children: [
+          _buildContainer(),
+          _buildCircleImage(),
+          _buildRateContainer(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRateContainer() {
+    return SizedBox(
+      width: double.infinity,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          SizedBox(height: 30),
+          Container(
+            width: 45,
+            height: 23,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: AppColors.secondary20,
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: Row(
+              spacing: 3,
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                const Icon(Icons.star, size: 15, color: AppColors.rating),
+                Text(
+                  '${widget.recipe.rate}',
+                  style: TextStyles.smallerTextRegular(
+                    color: AppColors.black,
+                    fontSize: 11,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Column _buildContainer() {
+    return Column(
+      children: [
+        SizedBox(height: 55),
+
+        Container(
+          alignment: Alignment.center,
+          height: 176,
+          width: 150,
+          decoration: BoxDecoration(
+            color: AppColors.primary40,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+            child: Column(
+              children: [
+                SizedBox(height: 66),
+                Text(
+                  widget.recipe.name,
+                  style: TextStyles.smallTextBold(color: AppColors.gray1),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+
+                Spacer(),
+
+                Row(
+                  children: [
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Time',
+                          style: TextStyles.smallerTextRegular(
+                            color: AppColors.gray3,
+                          ),
+                        ),
+
+                        SizedBox(height: 5),
+
+                        Text(
+                          '${widget.recipe.estimatedTime} min',
+                          style: TextStyles.smallerTextBold(
+                            color: AppColors.gray1,
+                          ),
+                        ),
+                      ],
+                    ),
+
+                    Spacer(),
+
+                    GestureDetector(
+                      onTap: () {
+                        widget.onTapFavorite(widget.recipe);
+                      },
+                      child: Container(
+                        width: 24,
+                        height: 24,
+                        decoration: const BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: AppColors.white,
+                        ),
+                        child:
+                            widget.recipe.isFavorite
+                                ? const Icon(
+                                  Icons.bookmark,
+                                  size: 16,
+                                  color: AppColors.primary80,
+                                )
+                                : const Icon(
+                                  Icons.bookmark_border,
+                                  size: 16,
+                                  color: AppColors.primary80,
+                                ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  ClipRRect _buildCircleImage() {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(110),
+      child: Image.network(
+        widget.recipe.imageUrl,
+        width: 110,
+        height: 110,
+        fit: BoxFit.cover,
+        loadingBuilder: (context, child, loadingProgress) {
+          if (loadingProgress == null) {
+            return child;
+          }
+          return Center(
+            child: CircularProgressIndicator(
+              value:
+                  loadingProgress.expectedTotalBytes != null
+                      ? loadingProgress.cumulativeBytesLoaded /
+                          loadingProgress.expectedTotalBytes!
+                      : null,
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/presentation/components/f_recipe_category_selector.dart
+++ b/lib/presentation/components/f_recipe_category_selector.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:recipe_app/ui/color_styles.dart';
+import 'package:recipe_app/ui/text_styles.dart';
+
+class FRecipeCategorySelector extends StatefulWidget {
+  final List<String> categories;
+  final void Function(String category) onSelectCategory;
+
+  const FRecipeCategorySelector({
+    super.key,
+    required this.onSelectCategory,
+    required this.categories,
+  });
+
+  @override
+  State<FRecipeCategorySelector> createState() =>
+      _FRecipeCategorySelectorState();
+}
+
+class _FRecipeCategorySelectorState extends State<FRecipeCategorySelector> {
+  String category = '';
+
+  @override
+  void initState() {
+    super.initState();
+    category = widget.categories[0];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final categories = widget.categories;
+
+    return SizedBox(
+      height: 51,
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        itemCount: categories.length,
+        itemBuilder: (context, index) {
+          return GestureDetector(
+            onTap: () {
+              _selectedCategory(index);
+            },
+            child: Container(
+              decoration: BoxDecoration(
+                color:
+                    categories[index] == category
+                        ? AppColors.primary100
+                        : AppColors.white,
+                borderRadius: BorderRadius.circular(10),
+              ),
+              padding: EdgeInsets.symmetric(vertical: 7, horizontal: 20),
+              child: Center(
+                child: Text(
+                  categories[index],
+                  style: TextStyles.smallerTextBold(
+                    color:
+                        categories[index] == category
+                            ? AppColors.white
+                            : AppColors.primary80,
+                  ),
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  void _selectedCategory(int index) {
+    setState(() {
+      category = widget.categories[index];
+      widget.onSelectCategory(widget.categories[index]);
+    });
+  }
+}

--- a/lib/presentation/home/home_action.dart
+++ b/lib/presentation/home/home_action.dart
@@ -1,0 +1,10 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'home_action.freezed.dart';
+
+@freezed
+sealed class HomeAction with _$HomeAction {
+  const factory HomeAction.onSearchFieldTap() = OnSearchFieldTap;
+  const factory HomeAction.onSelectCategory(String category) = OnSelectCategory;
+}
+

--- a/lib/presentation/home/home_action.dart
+++ b/lib/presentation/home/home_action.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:recipe_app/domain/model/recipe.dart';
 
 part 'home_action.freezed.dart';
 
@@ -6,5 +7,6 @@ part 'home_action.freezed.dart';
 sealed class HomeAction with _$HomeAction {
   const factory HomeAction.onSearchFieldTap() = OnSearchFieldTap;
   const factory HomeAction.onSelectCategory(String category) = OnSelectCategory;
+  const factory HomeAction.onTapFavorite(Recipe recipe) = OnTapFavorite;
 }
 

--- a/lib/presentation/home/home_event.dart
+++ b/lib/presentation/home/home_event.dart
@@ -1,0 +1,8 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'home_event.freezed.dart';
+
+@freezed
+sealed class HomeEvent with _$HomeEvent {
+  const factory HomeEvent.showSnackBar(String message) = ShowSnackBar;
+}

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -57,7 +57,9 @@ class _HomeScreenState extends State<HomeScreen> {
                         padding: const EdgeInsets.only(right: 16),
                         child: FDishCard(
                           recipe: widget.state.selectedCategoryRecipes[index],
-                          onTapFavorite: (Recipe recipe) {},
+                          onTapFavorite: (Recipe recipe) {
+                            widget.onAction(HomeAction.onTapFavorite(recipe));
+                          },
                         ),
                       );
                     },

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -45,14 +45,23 @@ class _HomeScreenState extends State<HomeScreen> {
                   categories: widget.state.categories,
                 ),
 
-                FDishCard(
-                  recipe: Recipe.empty.copyWith(
-                    imageUrl: 'https://picsum.photos/200?random=13',
-                    name: 'Classic',
-                    estimatedTime: 30,
-                    isFavorite: true,
+                SizedBox(height: 15,),
+
+                SizedBox(
+                  height: 231,
+                  child: ListView.builder(
+                    scrollDirection: Axis.horizontal,
+                    itemCount: widget.state.selectedCategoryRecipes.length,
+                    itemBuilder: (context, index) {
+                      return Padding(
+                        padding: const EdgeInsets.only(right: 16),
+                        child: FDishCard(
+                          recipe: widget.state.selectedCategoryRecipes[index],
+                          onTapFavorite: (Recipe recipe) {},
+                        ),
+                      );
+                    },
                   ),
-                  onTapFavorite: (Recipe recipe) {},
                 ),
               ],
             ),

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -1,14 +1,25 @@
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
-import 'package:recipe_app/core/routing/routes.dart';
 import 'package:recipe_app/presentation/components/f_input_field.dart';
 import 'package:recipe_app/presentation/components/f_search_filter_button.dart';
+import 'package:recipe_app/presentation/home/home_state.dart';
 import 'package:recipe_app/ui/color_styles.dart';
 import 'package:recipe_app/ui/text_styles.dart';
 
-class HomeScreen extends StatelessWidget {
-  const HomeScreen({super.key});
+class HomeScreen extends StatefulWidget {
+  final HomeState state;
+  final void Function() onSearchFieldTap;
 
+  const HomeScreen({
+    super.key,
+    required this.state,
+    required this.onSearchFieldTap,
+  });
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -62,9 +73,7 @@ class HomeScreen extends StatelessWidget {
                   children: [
                     Flexible(
                       child: GestureDetector(
-                        onTap: () {
-                          context.push(Routes.search);
-                        },
+                        onTap: widget.onSearchFieldTap,
                         child: AbsorbPointer(
                           child: FInputField(
                             placeHolder: 'Search recipe',

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -1,19 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:recipe_app/domain/model/recipe.dart';
+import 'package:recipe_app/presentation/components/f_dish_card.dart';
 import 'package:recipe_app/presentation/components/f_input_field.dart';
+import 'package:recipe_app/presentation/components/f_recipe_category_selector.dart';
 import 'package:recipe_app/presentation/components/f_search_filter_button.dart';
+import 'package:recipe_app/presentation/home/home_action.dart';
 import 'package:recipe_app/presentation/home/home_state.dart';
 import 'package:recipe_app/ui/color_styles.dart';
 import 'package:recipe_app/ui/text_styles.dart';
 
 class HomeScreen extends StatefulWidget {
   final HomeState state;
-  final void Function() onSearchFieldTap;
+  final void Function(HomeAction action) onAction;
 
-  const HomeScreen({
-    super.key,
-    required this.state,
-    required this.onSearchFieldTap,
-  });
+  const HomeScreen({super.key, required this.state, required this.onAction});
 
   @override
   State<HomeScreen> createState() => _HomeScreenState();
@@ -23,76 +23,102 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: AppColors.white,
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.symmetric(vertical: 20, horizontal: 30),
           child: IntrinsicHeight(
             child: Column(
               children: [
-                Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          'Hello Jega',
-                          style: TextStyles.largeTextBold(
-                            color: AppColors.black,
-                          ),
-                        ),
-                        SizedBox(height: 5),
-                        Text(
-                          'What are you cooking today?',
-                          style: TextStyles.smallerTextRegular(
-                            color: AppColors.gray3,
-                          ),
-                        ),
-                      ],
-                    ),
-
-                    Spacer(),
-
-                    Container(
-                      decoration: BoxDecoration(
-                        color: AppColors.secondary40,
-                        borderRadius: BorderRadius.circular(10),
-                      ),
-                      child: Image.asset(
-                        'assets/images/profile_image.png',
-                        width: 40,
-                        height: 40,
-                      ),
-                    ),
-                  ],
-                ),
+                _buildHeaderArea(),
 
                 SizedBox(height: 30),
 
-                Row(
-                  children: [
-                    Flexible(
-                      child: GestureDetector(
-                        onTap: widget.onSearchFieldTap,
-                        child: AbsorbPointer(
-                          child: FInputField(
-                            placeHolder: 'Search recipe',
-                            value: '',
-                            isVisibleSearchIcon: true,
-                            onValueChange: (_) {},
-                          ),
-                        ),
-                      ),
-                    ),
-                    SizedBox(width: 20),
-                    FSearchFilterButton(voidCallback: () {}),
-                  ],
+                _buildSearchBarArea(),
+
+                SizedBox(height: 15),
+
+                FRecipeCategorySelector(
+                  onSelectCategory: (category) {
+                    widget.onAction(HomeAction.onSelectCategory(category));
+                  },
+                  categories: widget.state.categories,
+                ),
+
+                FDishCard(
+                  recipe: Recipe.empty.copyWith(
+                    imageUrl: 'https://picsum.photos/200?random=13',
+                    name: 'Classic',
+                    estimatedTime: 30,
+                    isFavorite: true,
+                  ),
+                  onTapFavorite: (Recipe recipe) {},
                 ),
               ],
             ),
           ),
         ),
       ),
+    );
+  }
+
+  Row _buildSearchBarArea() {
+    return Row(
+      children: [
+        Flexible(
+          child: GestureDetector(
+            onTap: () {
+              widget.onAction(HomeAction.onSearchFieldTap());
+            },
+            child: AbsorbPointer(
+              child: FInputField(
+                placeHolder: 'Search recipe',
+                value: '',
+                isVisibleSearchIcon: true,
+                onValueChange: (_) {},
+              ),
+            ),
+          ),
+        ),
+        SizedBox(width: 20),
+        FSearchFilterButton(voidCallback: () {}),
+      ],
+    );
+  }
+
+  Row _buildHeaderArea() {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Hello Jega',
+              style: TextStyles.largeTextBold(color: AppColors.black),
+            ),
+            SizedBox(height: 5),
+            Text(
+              'What are you cooking today?',
+              style: TextStyles.smallerTextRegular(color: AppColors.gray3),
+            ),
+          ],
+        ),
+
+        Spacer(),
+
+        Container(
+          decoration: BoxDecoration(
+            color: AppColors.secondary40,
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: Image.asset(
+            'assets/images/profile_image.png',
+            width: 40,
+            height: 40,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/presentation/home/home_screen_root.dart
+++ b/lib/presentation/home/home_screen_root.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:recipe_app/core/routing/routes.dart';
+import 'package:recipe_app/presentation/home/home_screen.dart';
+import 'package:recipe_app/presentation/home/home_state.dart';
+import 'package:recipe_app/presentation/home/home_view_model.dart';
+
+class HomeScreenRoot extends StatefulWidget {
+  final HomeViewModel viewModel;
+
+  const HomeScreenRoot({super.key, required this.viewModel});
+
+  @override
+  State<HomeScreenRoot> createState() => _HomeScreenRootState();
+}
+
+class _HomeScreenRootState extends State<HomeScreenRoot> {
+  HomeViewModel get viewModel => widget.viewModel;
+
+  HomeState get state => widget.viewModel.state;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: viewModel,
+      builder: (_, _) {
+        return HomeScreen(
+          state: state,
+          onSearchFieldTap: () {
+            context.push(Routes.search);
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/presentation/home/home_screen_root.dart
+++ b/lib/presentation/home/home_screen_root.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:recipe_app/core/routing/routes.dart';
+import 'package:recipe_app/presentation/home/home_action.dart';
 import 'package:recipe_app/presentation/home/home_screen.dart';
 import 'package:recipe_app/presentation/home/home_state.dart';
 import 'package:recipe_app/presentation/home/home_view_model.dart';
@@ -26,8 +27,15 @@ class _HomeScreenRootState extends State<HomeScreenRoot> {
       builder: (_, _) {
         return HomeScreen(
           state: state,
-          onSearchFieldTap: () {
-            context.push(Routes.search);
+          onAction: (HomeAction action) {
+            switch (action) {
+              case OnSearchFieldTap():
+                context.push(Routes.search);
+                break;
+              case OnSelectCategory():
+
+                break;
+            }
           },
         );
       },

--- a/lib/presentation/home/home_screen_root.dart
+++ b/lib/presentation/home/home_screen_root.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:recipe_app/core/routing/routes.dart';
@@ -21,6 +23,12 @@ class _HomeScreenRootState extends State<HomeScreenRoot> {
   HomeState get state => widget.viewModel.state;
 
   @override
+  void initState() {
+    super.initState();
+    viewModel.fetchSearchRecipesWithFilters();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return ListenableBuilder(
       listenable: viewModel,
@@ -33,7 +41,7 @@ class _HomeScreenRootState extends State<HomeScreenRoot> {
                 context.push(Routes.search);
                 break;
               case OnSelectCategory():
-
+                viewModel.setCategory(action.category);
                 break;
             }
           },

--- a/lib/presentation/home/home_screen_root.dart
+++ b/lib/presentation/home/home_screen_root.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:recipe_app/core/routing/routes.dart';
@@ -42,6 +40,9 @@ class _HomeScreenRootState extends State<HomeScreenRoot> {
                 break;
               case OnSelectCategory():
                 viewModel.setCategory(action.category);
+                break;
+              case OnTapFavorite():
+                viewModel.toggleFavorite(action.recipe);
                 break;
             }
           },

--- a/lib/presentation/home/home_state.dart
+++ b/lib/presentation/home/home_state.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:recipe_app/domain/model/type/category_filter_type.dart';
 
 part 'home_state.freezed.dart';
 
@@ -7,5 +8,7 @@ abstract class HomeState with _$HomeState {
   const factory HomeState({
     @Default(false) bool isLoading,
     @Default(null) String? errorMessage,
+    required List<String> categories,
+    @Default(CategoryFilterType.all) CategoryFilterType selectedCategory,
   }) = _HomeState;
 }

--- a/lib/presentation/home/home_state.dart
+++ b/lib/presentation/home/home_state.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:recipe_app/domain/model/recipe.dart';
 import 'package:recipe_app/domain/model/type/category_filter_type.dart';
 
 part 'home_state.freezed.dart';
@@ -10,5 +11,6 @@ abstract class HomeState with _$HomeState {
     @Default(null) String? errorMessage,
     required List<String> categories,
     @Default(CategoryFilterType.all) CategoryFilterType selectedCategory,
+    @Default([]) List<Recipe> selectedCategoryRecipes
   }) = _HomeState;
 }

--- a/lib/presentation/home/home_state.dart
+++ b/lib/presentation/home/home_state.dart
@@ -1,0 +1,11 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'home_state.freezed.dart';
+
+@freezed
+abstract class HomeState with _$HomeState {
+  const factory HomeState({
+    @Default(false) bool isLoading,
+    @Default(null) String? errorMessage,
+  }) = _HomeState;
+}

--- a/lib/presentation/home/home_view_model.dart
+++ b/lib/presentation/home/home_view_model.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+import 'package:recipe_app/presentation/home/home_state.dart';
+
+class HomeViewModel with ChangeNotifier {
+  HomeState _state = const HomeState();
+
+  HomeState get state => _state;
+}

--- a/lib/presentation/home/home_view_model.dart
+++ b/lib/presentation/home/home_view_model.dart
@@ -1,23 +1,48 @@
 import 'package:flutter/material.dart';
 import 'package:recipe_app/domain/model/type/category_filter_type.dart';
+import 'package:recipe_app/domain/use_case/get_saved_recipes_use_case.dart';
 import 'package:recipe_app/presentation/home/home_state.dart';
 
 class HomeViewModel with ChangeNotifier {
+  final GetSavedRecipesUseCase _getSavedRecipesUseCase;
   HomeState _state;
 
   HomeState get state => _state;
 
-  HomeViewModel({HomeState? state})
-    : _state =
-          state ??
-          HomeState(
-            categories: CategoryFilterType.values.map((e) => e.name).toList(),
-          );
+  HomeViewModel({
+    required GetSavedRecipesUseCase getSavedRecipesUseCase,
+    HomeState? state,
+  }) : _state =
+           state ??
+           HomeState(
+             categories: CategoryFilterType.values.map((e) => e.name).toList(),
+           ),
+       _getSavedRecipesUseCase = getSavedRecipesUseCase;
 
-  void setCategory(String category) {
+  void setCategory(String category) async {
     _state = _state.copyWith(
       selectedCategory: CategoryFilterTypeExtension.fromString(category),
     );
+    await fetchSearchRecipesWithFilters();
+  }
+
+  Future<void> fetchSearchRecipesWithFilters() async {
+    _state = state.copyWith(isLoading: true, errorMessage: null);
     notifyListeners();
+
+    try {
+      final searchedRecipes = await _getSavedRecipesUseCase.getSavedRecipes(
+        categoryFilterType: state.selectedCategory,
+      );
+
+      _state = state.copyWith(
+        selectedCategoryRecipes: searchedRecipes,
+        isLoading: false,
+      );
+      notifyListeners();
+    } catch (e) {
+      _state = state.copyWith(errorMessage: e.toString(), isLoading: false);
+      notifyListeners();
+    }
   }
 }

--- a/lib/presentation/home/home_view_model.dart
+++ b/lib/presentation/home/home_view_model.dart
@@ -1,23 +1,28 @@
 import 'package:flutter/material.dart';
+import 'package:recipe_app/domain/model/recipe.dart';
 import 'package:recipe_app/domain/model/type/category_filter_type.dart';
 import 'package:recipe_app/domain/use_case/get_saved_recipes_use_case.dart';
+import 'package:recipe_app/domain/use_case/toggle_favorite_use_case.dart';
 import 'package:recipe_app/presentation/home/home_state.dart';
 
 class HomeViewModel with ChangeNotifier {
   final GetSavedRecipesUseCase _getSavedRecipesUseCase;
+  final ToggleFavoriteUseCase _toggleFavoriteUseCase;
   HomeState _state;
 
   HomeState get state => _state;
 
   HomeViewModel({
     required GetSavedRecipesUseCase getSavedRecipesUseCase,
+    required ToggleFavoriteUseCase toggleFavoriteUseCase,
     HomeState? state,
   }) : _state =
            state ??
            HomeState(
              categories: CategoryFilterType.values.map((e) => e.name).toList(),
            ),
-       _getSavedRecipesUseCase = getSavedRecipesUseCase;
+       _getSavedRecipesUseCase = getSavedRecipesUseCase,
+        _toggleFavoriteUseCase = toggleFavoriteUseCase;
 
   void setCategory(String category) async {
     _state = _state.copyWith(
@@ -42,6 +47,28 @@ class HomeViewModel with ChangeNotifier {
       notifyListeners();
     } catch (e) {
       _state = state.copyWith(errorMessage: e.toString(), isLoading: false);
+      notifyListeners();
+    }
+  }
+
+  Future<void> toggleFavorite(Recipe recipe) async {
+    final id = recipe.id;
+    _state = state.copyWith(isLoading: true, errorMessage: null);
+    notifyListeners();
+
+    try {
+      final toggledRecipe = await _toggleFavoriteUseCase.toggleFavorite(id);
+      final index = state.selectedCategoryRecipes.indexWhere((recipe) => recipe.id == id);
+      _state = state.copyWith(
+        selectedCategoryRecipes:
+            List.from(state.selectedCategoryRecipes)
+              ..removeAt(index)
+              ..insert(index, toggledRecipe),
+      );
+    } catch (e) {
+      _state = state.copyWith(errorMessage: e.toString());
+    } finally {
+      _state = state.copyWith(isLoading: false);
       notifyListeners();
     }
   }

--- a/lib/presentation/home/home_view_model.dart
+++ b/lib/presentation/home/home_view_model.dart
@@ -1,8 +1,23 @@
 import 'package:flutter/material.dart';
+import 'package:recipe_app/domain/model/type/category_filter_type.dart';
 import 'package:recipe_app/presentation/home/home_state.dart';
 
 class HomeViewModel with ChangeNotifier {
-  HomeState _state = const HomeState();
+  HomeState _state;
 
   HomeState get state => _state;
+
+  HomeViewModel({HomeState? state})
+    : _state =
+          state ??
+          HomeState(
+            categories: CategoryFilterType.values.map((e) => e.name).toList(),
+          );
+
+  void setCategory(String category) {
+    _state = _state.copyWith(
+      selectedCategory: CategoryFilterTypeExtension.fromString(category),
+    );
+    notifyListeners();
+  }
 }

--- a/lib/presentation/splash_screen/splash_action.dart
+++ b/lib/presentation/splash_screen/splash_action.dart
@@ -1,0 +1,8 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'splash_action.freezed.dart';
+
+@freezed
+sealed class SplashAction with _$SplashAction {
+  const factory SplashAction.onTapButton() = OnTapButton;
+}

--- a/lib/presentation/splash_screen/splash_screen.dart
+++ b/lib/presentation/splash_screen/splash_screen.dart
@@ -4,47 +4,23 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:recipe_app/core/routing/routes.dart';
 import 'package:recipe_app/presentation/components/f_medium_button.dart';
+import 'package:recipe_app/presentation/splash_screen/splash_action.dart';
 import 'package:recipe_app/presentation/splash_screen/splash_event.dart';
-import 'package:recipe_app/presentation/splash_screen/splash_view_model.dart';
+import 'package:recipe_app/presentation/splash_screen/splash_state.dart';
 import 'package:recipe_app/ui/text_styles.dart';
 
 class SplashScreen extends StatefulWidget {
-  final SplashViewModel splashViewModel;
+  final SplashState state;
+  final void Function(SplashAction action) onAction;
 
-  const SplashScreen({super.key, required this.splashViewModel});
+  const SplashScreen({super.key, required this.state, required this.onAction});
 
   @override
   State<SplashScreen> createState() => _SplashScreenState();
 }
 
 class _SplashScreenState extends State<SplashScreen> {
-  StreamSubscription<SplashEvent>? _subscription;
 
-  @override
-  void initState() {
-    super.initState();
-    bindSplashEvent();
-    widget.splashViewModel.getSettings();
-  }
-
-  void bindSplashEvent() {
-    _subscription = widget.splashViewModel.eventStream.listen((event) {
-      if (mounted) {
-        switch (event) {
-          case ShowErrorMessage():
-            ScaffoldMessenger.of(
-              context,
-            ).showSnackBar(SnackBar(content: Text(event.message)));
-        }
-      }
-    });
-  }
-
-  @override
-  void dispose() {
-    _subscription?.cancel();
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -111,7 +87,7 @@ class _SplashScreenState extends State<SplashScreen> {
                   FMediumButton(
                     text: 'Start Cooking',
                     voidCallback: () {
-                      context.pushReplacement(Routes.signIn);
+                      widget.onAction(OnTapButton());
                     },
                   ),
 

--- a/lib/presentation/splash_screen/splash_screen_root.dart
+++ b/lib/presentation/splash_screen/splash_screen_root.dart
@@ -1,0 +1,68 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:recipe_app/core/routing/routes.dart';
+import 'package:recipe_app/presentation/splash_screen/splash_action.dart';
+import 'package:recipe_app/presentation/splash_screen/splash_event.dart';
+import 'package:recipe_app/presentation/splash_screen/splash_screen.dart';
+import 'package:recipe_app/presentation/splash_screen/splash_state.dart';
+import 'package:recipe_app/presentation/splash_screen/splash_view_model.dart';
+
+class SplashScreenRoot extends StatefulWidget {
+  final SplashViewModel viewModel;
+
+  const SplashScreenRoot({super.key, required this.viewModel});
+
+  @override
+  State<SplashScreenRoot> createState() => _SplashScreenRootState();
+}
+
+class _SplashScreenRootState extends State<SplashScreenRoot> {
+  SplashViewModel get viewModel => widget.viewModel;
+
+  SplashState get state => widget.viewModel.state;
+
+  StreamSubscription<SplashEvent>? _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.viewModel.getSettings();
+    bindSplashEvent();
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
+  }
+
+  void bindSplashEvent() {
+    _subscription = widget.viewModel.eventStream.listen((event) {
+      if (mounted) {
+        switch (event) {
+          case ShowErrorMessage():
+            ScaffoldMessenger.of(
+              context,
+            ).showSnackBar(SnackBar(content: Text(event.message)));
+        }
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: viewModel,
+      builder: (_, __) {
+        return SplashScreen(state: state, onAction: (SplashAction action) {
+          switch (action) {
+            case OnTapButton():
+              context.pushReplacement(Routes.signIn);
+          }
+        },);
+      },
+    );
+  }
+}

--- a/lib/presentation/splash_screen/splash_state.dart
+++ b/lib/presentation/splash_screen/splash_state.dart
@@ -1,0 +1,11 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'splash_state.freezed.dart';
+
+@freezed
+abstract class SplashState with _$SplashState {
+  const factory SplashState({
+    @Default(false) bool isLoading,
+    @Default(null) String? errorMessage,
+  }) = _SplashState;
+}

--- a/lib/presentation/splash_screen/splash_view_model.dart
+++ b/lib/presentation/splash_screen/splash_view_model.dart
@@ -3,22 +3,27 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:recipe_app/domain/use_case/throw_when_settings_info_use_case.dart';
 import 'package:recipe_app/presentation/splash_screen/splash_event.dart';
+import 'package:recipe_app/presentation/splash_screen/splash_state.dart';
 
 class SplashViewModel with ChangeNotifier {
   final ThrowWhenSettingsInfoUseCase _throwWhenSettingsInfoUseCase;
-
-  SplashViewModel({
-    required ThrowWhenSettingsInfoUseCase throwWhenSettingsInfoUseCase,
-  }) : _throwWhenSettingsInfoUseCase = throwWhenSettingsInfoUseCase;
 
   final _eventController = StreamController<SplashEvent>();
 
   Stream<SplashEvent> get eventStream => _eventController.stream;
 
+  SplashState _state = SplashState();
+
+  SplashState get state => _state;
+
+  SplashViewModel({
+    required ThrowWhenSettingsInfoUseCase throwWhenSettingsInfoUseCase,
+  }) : _throwWhenSettingsInfoUseCase = throwWhenSettingsInfoUseCase;
+
   void getSettings() async {
     try {
       final _ = await _throwWhenSettingsInfoUseCase.getSettings();
-    } catch (e, stackTrace) {
+    } catch (e) {
       _eventController.add(SplashEvent.showErrorMessage(e.toString()));
     }
   }

--- a/test/presentation/home/home_screen_test.dart
+++ b/test/presentation/home/home_screen_test.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_test/flutter_test.dart';
+
+
+void main() {
+  testWidgets('', (WidgetTester tester) async {
+
+  });
+}


### PR DESCRIPTION
# 230422_16_김옥현

## 📝 과제 정보

- 교육 주제: 고급 상태관리 기법

## ✅ 구현 내용

- 홈 화면(HomeScreen) UI 구현
- 홈 화면에 필요한 MVVM, MVI 아키텍처 패턴 구현 (HomeViewModel, HomeState, HomeAction 등)
- 카테고리 선택 컴포넌트(FRecipeCategorySelector) 구현
- 레시피 카드 컴포넌트(FDishCard) 구현

## 📋 체크리스트

- [x] HomeState, HomeAction 구현
- [x] 재사용 가능한 UI 컴포넌트 구현 (FDishCard, FRecipeCategorySelector)
- [x] 카테고리 필터링 기능 구현
- [x] 즐겨찾기 토글 기능 구현
- [ ] 테스트 코드 작성
- [ ] MVI 패턴, root screen 리팩토링
  - [x] SplashScreen

## 🔍 구현 방법

- MVVM, MVI 패턴을 적용하여 화면(View), 비즈니스 로직(ViewModel), 상태(State) 관리를 분리

## 📷 실행 결과

<img src="https://github.com/user-attachments/assets/619ed3f7-62e8-42a3-af30-9fe4985c53f2" width="40%">



## 🚨 어려웠던 점

- 상태관리 관련 뎁스가 점점 깊어지면서 헷갈리게 되는 것 같다.

## 💡 배운 점

- State, Action을 통한 관심사 분리 및 테스트가 용이하게끔 구조를 설계하는 것을 배워 너무 좋았습니다.

## ❓ 질문 사항



## 📚 참고 자료

- https://pub.dev/packages/go_router

## 🔄 자체 평가 & 회고

수업을 진행하게 되면서 아키텍처가 빌드업 해나가는게 성취감도 있고 MVI 구조에 대해 왜 이렇게 쓰는지 알게되서 너무 좋았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 홈 화면에 레시피 카드(FDishCard) 및 카테고리 선택(FRecipeCategorySelector) 위젯 추가
  - 홈 화면 상태(HomeState), 뷰모델(HomeViewModel), 액션/이벤트(HomeAction, HomeEvent) 구조 도입
  - 스플래시 화면 상태(SplashState), 뷰모델(SplashViewModel), 액션(SplashAction) 구조 도입
  - 홈/스플래시 화면의 Root 위젯(HomeScreenRoot, SplashScreenRoot) 추가로 상태 및 이벤트 관리 개선

- **버그 수정**
  - 레시피 즐겨찾기, 카테고리 선택 등 홈 화면 상호작용의 일관성 및 반응성 개선

- **리팩터링**
  - 라우팅 및 화면 구조를 Root 위젯 기반으로 재구성
  - 기존 화면 위젯의 상태 관리 및 콜백 방식으로 구조 변경

- **테스트**
  - 홈 화면 위젯 테스트 파일 추가(테스트 내용은 미구현)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->