### PR TITLE
250422_14_김동성

### DIFF
--- a/lib/core/result/result.dart
+++ b/lib/core/result/result.dart
@@ -1,0 +1,9 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'result.freezed.dart';
+
+@freezed
+class Result<T> with _$Result<T>{
+  const factory Result.success(T data) = Success;
+  const factory Result.error(Exception e) = Errors;
+}

--- a/lib/core/routing/router.dart
+++ b/lib/core/routing/router.dart
@@ -1,23 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:http/http.dart' as http;
+
 import 'package:recipe_app/core/di/di_setup.dart';
 import 'package:recipe_app/core/routing/routes.dart';
-import 'package:recipe_app/data/data_source/mock_recipe_data_source.dart';
-import 'package:recipe_app/data/data_source/mock_user_data_source.dart';
-import 'package:recipe_app/data/repository/bookmark_repository_impl.dart';
-import 'package:recipe_app/data/repository/mock_recipe_repository_impl.dart';
-import 'package:recipe_app/data/repository/mock_user_repository_impl.dart';
-import 'package:recipe_app/domain/use_case/get_saved_recipes_use_case.dart';
+
 import 'package:recipe_app/presentation/bottom_navigation_bar/bottom_navigation_bar_screen.dart';
 import 'package:recipe_app/presentation/home/home_screen.dart';
-import 'package:recipe_app/presentation/ingredient/ingredient_screen.dart';
+
+import 'package:recipe_app/presentation/ingredient/ingredient_screen_root.dart';
 import 'package:recipe_app/presentation/ingredient/ingredient_view_model.dart';
-import 'package:recipe_app/presentation/saved_recipes/saved_recipes_screen.dart';
+
 import 'package:recipe_app/presentation/saved_recipes/saved_recipes_screen_root.dart';
-import 'package:recipe_app/presentation/saved_recipes/saved_recipes_view_model.dart';
-import 'package:recipe_app/presentation/search_recipes/search_recipes_screen.dart';
-import 'package:recipe_app/presentation/search_recipes/search_recipes_view_model.dart';
+
+import 'package:recipe_app/presentation/search_recipes/search_recipes_screen_root.dart';
+
 import 'package:recipe_app/presentation/sign_in/sign_in_screen.dart';
 import 'package:recipe_app/presentation/sign_up/sign_up_screen.dart';
 import 'package:recipe_app/presentation/splash/splash_screen.dart';
@@ -38,7 +34,7 @@ final router = GoRouter(
 
         viewModel.loadRecipe(recipeId);
         viewModel.getUserModel(4);
-        return IngredientScreen(viewModel: viewModel);
+        return IngredientScreenRoot(viewModel: viewModel);
       },
     ),
     ShellRoute(
@@ -69,7 +65,7 @@ final router = GoRouter(
 
     GoRoute(
       path: Routes.search,
-      builder: (context, state) => SearchRecipesScreen(viewModel: getIt()),
+      builder: (context, state) => SearchRecipesScreenRoot(viewModel: getIt()),
     ),
   ],
 );

--- a/lib/core/routing/router.dart
+++ b/lib/core/routing/router.dart
@@ -14,6 +14,7 @@ import 'package:recipe_app/presentation/home/home_screen.dart';
 import 'package:recipe_app/presentation/ingredient/ingredient_screen.dart';
 import 'package:recipe_app/presentation/ingredient/ingredient_view_model.dart';
 import 'package:recipe_app/presentation/saved_recipes/saved_recipes_screen.dart';
+import 'package:recipe_app/presentation/saved_recipes/saved_recipes_screen_root.dart';
 import 'package:recipe_app/presentation/saved_recipes/saved_recipes_view_model.dart';
 import 'package:recipe_app/presentation/search_recipes/search_recipes_screen.dart';
 import 'package:recipe_app/presentation/search_recipes/search_recipes_view_model.dart';
@@ -47,33 +48,28 @@ final router = GoRouter(
       routes: [
         GoRoute(
           path: Routes.home,
-          builder:
-              (context, state) => HomeScreen(
-                viewModel: getIt(),
-              ),
+          builder: (context, state) => HomeScreen(viewModel: getIt()),
         ),
         GoRoute(
           path: Routes.savedRecipes,
           builder:
-              (context, state) => SavedRecipesScreen(
-                viewModel: getIt(),
-              ),
+              (context, state) => SavedRecipesScreenRoot(viewModel: getIt()),
         ),
       ],
     ),
 
     GoRoute(path: "/", builder: (context, state) => ComponentTestScreen()),
 
-    GoRoute(path: Routes.splash, builder: (context, state) => SplashScreen(viewModel: getIt(),)),
+    GoRoute(
+      path: Routes.splash,
+      builder: (context, state) => SplashScreen(viewModel: getIt()),
+    ),
     GoRoute(path: Routes.signIn, builder: (context, state) => SignInScreen()),
     GoRoute(path: Routes.signUp, builder: (context, state) => SignUpScreen()),
 
     GoRoute(
       path: Routes.search,
-      builder:
-          (context, state) => SearchRecipesScreen(
-            viewModel: getIt(),
-          ),
+      builder: (context, state) => SearchRecipesScreen(viewModel: getIt()),
     ),
   ],
 );

--- a/lib/data/data_source/mock_recipe_data_source.dart
+++ b/lib/data/data_source/mock_recipe_data_source.dart
@@ -23,9 +23,9 @@ class MockRecipeDataSource implements RecipeDataSource {
     final List<Map<String, dynamic>> result =
         recipeList.map((e) {
           String category = e["category"];
-          String imageUrl = e["image"];
+          // String imageUrl = e["image"];
           e["category"] = category.toLowerCase();
-          
+
           return e as Map<String, dynamic>;
         }).toList();
     return result;

--- a/lib/presentation/component/input_field.dart
+++ b/lib/presentation/component/input_field.dart
@@ -8,13 +8,14 @@ class InputField extends StatefulWidget {
   final bool isSearch;
   final TextEditingController controller;
   final Function(String) onValueChange;
+  final VoidCallback onTap;
   const InputField({
     super.key,
     required this.label,
     required this.placeHolder,
     required this.onValueChange,
     required this.controller,
-    required this.isSearch,
+    required this.isSearch, required this.onTap,
   });
 
   @override
@@ -49,8 +50,10 @@ class _InputFieldState extends State<InputField> {
           width: double.infinity,
           child: TextFormField(
             controller: _textEditingController,
+            onTap: () {
+              widget.onTap();
+            },
             onChanged: (value) {
-              print(value);
               widget.onValueChange(value);
             },
             decoration: InputDecoration(

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -78,6 +78,9 @@ class _HomeScreenState extends State<HomeScreen> {
                           onValueChange: (String value) async {
                             await widget.viewModel.fetchSearchedRecipes(value);
                           },
+                          onTap: () {
+                            context.push(Routes.search);
+                          },
                         ),
                       ),
                       FilterList(

--- a/lib/presentation/ingredient/ingredient_screen.dart
+++ b/lib/presentation/ingredient/ingredient_screen.dart
@@ -1,17 +1,15 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:recipe_app/presentation/component/ingredient_item.dart';
 import 'package:recipe_app/presentation/component/recipe_card.dart';
-import 'package:recipe_app/presentation/component/small_button.dart';
 import 'package:recipe_app/presentation/component/tabs.dart';
+import 'package:recipe_app/presentation/ingredient/ingredient_state.dart';
 
-import 'package:recipe_app/presentation/ingredient/ingredient_view_model.dart';
 import 'package:recipe_app/ui/color_style.dart';
 import 'package:recipe_app/ui/text_style.dart';
 
 class IngredientScreen extends StatefulWidget {
-  final IngredientViewModel viewModel;
-  const IngredientScreen({super.key, required this.viewModel});
+  final IngredientState state;
+  const IngredientScreen({super.key, required this.state});
 
   @override
   State<IngredientScreen> createState() => _IngredientScreenState();
@@ -21,10 +19,7 @@ class _IngredientScreenState extends State<IngredientScreen> {
   int selectedIndex = 0;
   @override
   Widget build(BuildContext context) {
-    return ListenableBuilder(
-      listenable: widget.viewModel,
-      builder: (context, child) {
-        return SafeArea(
+    return SafeArea(
           child: Scaffold(
             appBar: AppBar(),
             body: SingleChildScrollView(
@@ -33,7 +28,7 @@ class _IngredientScreenState extends State<IngredientScreen> {
                 child: Column(
                   children: [
                     RecipeCard(
-                      recipe: widget.viewModel.recipe,
+                      recipe: widget.state.recipe,
                       isBig: true,
                       isBookmarked: true,
                       isIngredient: true,
@@ -46,7 +41,7 @@ class _IngredientScreenState extends State<IngredientScreen> {
                         SizedBox(
                           width: MediaQuery.sizeOf(context).width * 0.5,
                           child: Text(
-                            widget.viewModel.recipe.title,
+                            widget.state.recipe.title,
                             maxLines: 2,
                             style: TextStyles.smallTextBold,
                           ),
@@ -68,9 +63,18 @@ class _IngredientScreenState extends State<IngredientScreen> {
                             children: [
                               CircleAvatar(
                                 backgroundImage:
-                                    widget.viewModel.userModel.image.isNotEmpty
+                                    widget
+                                            
+                                            .state
+                                            .userModel
+                                            .image
+                                            .isNotEmpty
                                         ? NetworkImage(
-                                          widget.viewModel.userModel.image,
+                                          widget
+                                              
+                                              .state
+                                              .userModel
+                                              .image,
                                         )
                                         : null,
                               ),
@@ -79,7 +83,7 @@ class _IngredientScreenState extends State<IngredientScreen> {
                                 crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
                                   Text(
-                                    widget.viewModel.userModel.name,
+                                    widget.state.userModel.name,
                                     style: TextStyles.smallTextBold,
                                   ),
                                   Row(
@@ -89,7 +93,11 @@ class _IngredientScreenState extends State<IngredientScreen> {
                                         color: ColorStyles.primary100,
                                       ),
                                       Text(
-                                        widget.viewModel.userModel.address,
+                                        widget
+                                            
+                                            .state
+                                            .userModel
+                                            .address,
                                         style: TextStyles.smallerTextRegular
                                             .copyWith(color: ColorStyles.gray3),
                                       ),
@@ -123,9 +131,8 @@ class _IngredientScreenState extends State<IngredientScreen> {
                       labels: ["Ingredient", "Procedure"],
                       selectedIndex: 0,
                       onValueChange: (int value) {
-                        selectedIndex = value;
                         setState(() {
-                          print(selectedIndex);
+                          selectedIndex = value;
                         });
                       },
                     ),
@@ -150,7 +157,7 @@ class _IngredientScreenState extends State<IngredientScreen> {
                           ),
                         ),
                         Text(
-                          "${widget.viewModel.recipe.ingredients.length} Items",
+                          "${widget.state.recipe.ingredients.length} Items",
                           style: TextStyles.smallerTextRegular.copyWith(
                             color: ColorStyles.gray3,
                           ),
@@ -158,11 +165,6 @@ class _IngredientScreenState extends State<IngredientScreen> {
                       ],
                     ),
                     SizedBox(height: 20),
-                    // for (final ingredients
-                    //     in widget.viewModel.recipe.ingredients) ...[
-                    //   IngredientItem(ingredients: ingredients),
-                    //   SizedBox(height: 10),
-                    // ],
                     if (selectedIndex == 0)
                       ListView.separated(
                         shrinkWrap: true,
@@ -170,13 +172,18 @@ class _IngredientScreenState extends State<IngredientScreen> {
                         itemBuilder: (context, index) {
                           return IngredientItem(
                             ingredients:
-                                widget.viewModel.recipe.ingredients[index],
+                                widget
+                                    
+                                    .state
+                                    .recipe
+                                    .ingredients[index],
                           );
                         },
                         separatorBuilder: (context, index) {
                           return SizedBox(height: 10);
                         },
-                        itemCount: widget.viewModel.recipe.ingredients.length,
+                        itemCount:
+                            widget.state.recipe.ingredients.length,
                       ),
                   ],
                 ),
@@ -184,7 +191,6 @@ class _IngredientScreenState extends State<IngredientScreen> {
             ),
           ),
         );
-      },
-    );
+
   }
 }

--- a/lib/presentation/ingredient/ingredient_screen_root.dart
+++ b/lib/presentation/ingredient/ingredient_screen_root.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:recipe_app/presentation/ingredient/ingredient_screen.dart';
+import 'package:recipe_app/presentation/ingredient/ingredient_view_model.dart';
+
+class IngredientScreenRoot extends StatefulWidget {
+  final IngredientViewModel viewModel;
+  const IngredientScreenRoot({super.key, required this.viewModel});
+
+  @override
+  State<IngredientScreenRoot> createState() => _IngredientScreenRootState();
+}
+
+class _IngredientScreenRootState extends State<IngredientScreenRoot> {
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: widget.viewModel,
+      builder: (context, child) {
+        return IngredientScreen(state: widget.viewModel.state,);
+      },
+    );
+  }
+}

--- a/lib/presentation/ingredient/ingredient_state.dart
+++ b/lib/presentation/ingredient/ingredient_state.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:recipe_app/domain/model/recipe.dart';
+import 'package:recipe_app/domain/model/user.dart';
+
+part 'ingredient_state.freezed.dart';
+
+@freezed
+abstract class IngredientState with _$IngredientState{
+  const factory IngredientState({
+    @Default(Recipe()) final Recipe recipe,
+    @Default(User()) final User userModel,
+    @Default(false) final bool isLoading
+  }) = _IngredientState;
+}

--- a/lib/presentation/ingredient/ingredient_view_model.dart
+++ b/lib/presentation/ingredient/ingredient_view_model.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:recipe_app/domain/model/recipe.dart';
-import 'package:recipe_app/domain/model/user.dart';
 import 'package:recipe_app/domain/use_case/get_saved_recipes_use_case.dart';
+import 'package:recipe_app/presentation/ingredient/ingredient_state.dart';
 
 class IngredientViewModel with ChangeNotifier {
   final GetSavedRecipesUseCase _getSavedRecipesUseCase;
@@ -9,30 +8,24 @@ class IngredientViewModel with ChangeNotifier {
   IngredientViewModel({required GetSavedRecipesUseCase getSavedRecipesUseCase})
     : _getSavedRecipesUseCase = getSavedRecipesUseCase;
 
-  Recipe _recipe = Recipe();
-  Recipe get recipe => _recipe;
-
-  User _userModel = User();
-  User get userModel => _userModel;
-
-  bool _isLoading = false;
-  bool get isLoading => _isLoading;
+  IngredientState _state = const IngredientState();
+  IngredientState get state => _state;
 
   Future<void> loadRecipe(int recipeId) async {
-    _isLoading = true;
+    _state = _state.copyWith(isLoading: true);
     notifyListeners();
-    _recipe = await _getSavedRecipesUseCase.getRecipeWithId(recipeId);
 
-    _isLoading = false;
+    final recipe = await _getSavedRecipesUseCase.getRecipeWithId(recipeId);
+    _state = _state.copyWith(isLoading: false, recipe: recipe);
     notifyListeners();
   }
 
   Future<void> getUserModel(int userId) async {
-    _isLoading = true;
+    _state = _state.copyWith(isLoading: true);
     notifyListeners();
-    _userModel = await _getSavedRecipesUseCase.getUserModel(userId);
 
-    _isLoading = false;
+    final userModel = await _getSavedRecipesUseCase.getUserModel(userId);
+    _state = _state.copyWith(isLoading: false, userModel: userModel);
     notifyListeners();
   }
 }

--- a/lib/presentation/saved_recipes/saved_recipes_action.dart
+++ b/lib/presentation/saved_recipes/saved_recipes_action.dart
@@ -1,0 +1,9 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'saved_recipes_action.freezed.dart';
+
+@freezed
+sealed class SavedRecipesAction with _$SavedRecipesAction{
+  const factory SavedRecipesAction.onTapRecipe(int recipeId) = OnTapRecipe;
+  const factory SavedRecipesAction.onTapBookmark(int recipeId) = OnTapBookmark;
+}

--- a/lib/presentation/saved_recipes/saved_recipes_screen.dart
+++ b/lib/presentation/saved_recipes/saved_recipes_screen.dart
@@ -1,60 +1,65 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:recipe_app/presentation/component/recipe_card.dart';
+import 'package:recipe_app/presentation/saved_recipes/saved_recipes_action.dart';
+import 'package:recipe_app/presentation/saved_recipes/saved_recipes_state.dart';
 import 'package:recipe_app/presentation/saved_recipes/saved_recipes_view_model.dart';
 import 'package:recipe_app/ui/text_style.dart';
 
 class SavedRecipesScreen extends StatelessWidget {
-  final SavedRecipesViewModel viewModel;
-  const SavedRecipesScreen({super.key, required this.viewModel});
+  final SavedRecipesState state;
+  final void Function(SavedRecipesAction action) onAction;
+  const SavedRecipesScreen({
+    super.key,
+    required this.state,
+    required this.onAction,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return ListenableBuilder(
-      listenable: viewModel,
-      builder: (context, child) {
-        return SafeArea(
-          child: Scaffold(
-            appBar: AppBar(
-              title: Text("Saved recipes", style: TextStyles.mediumTextBold),
-            ),
-            body: SingleChildScrollView(
-              child: Padding(
-                padding: EdgeInsets.symmetric(horizontal: 24),
-                child: Column(
-                  children: [
-                    SizedBox(height: 24),
-                    if (viewModel.isLoading)
-                      const Center(child: CircularProgressIndicator()),
-                    if (!viewModel.isLoading && viewModel.recipes.isEmpty)
-                      const Center(child: Text("저장된 레시피가 없습니다.")),
-                    for (final recipe in viewModel.recipes) ...[
-                      GestureDetector(
-                        onTap: () {
-                          context.push("/ingredient/${recipe.recipeId}");
-                        },
-                        child: RecipeCard(
-                          recipe: recipe,
-                          isBig: true,
-                          isBookmarked:
-                              viewModel.bookMarkList.contains(recipe.recipeId)
-                                  ? true
-                                  : false,
-                                  isIngredient: false,
-                          bookMarkCallback: () async {
-                            await viewModel.bookmarkRecipe(recipe.recipeId);
-                          },
-                        ),
-                      ),
-                      SizedBox(height: 24),
-                    ],
-                  ],
-                ),
-              ),
+    return SafeArea(
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text("Saved recipes", style: TextStyles.mediumTextBold),
+        ),
+        body: SingleChildScrollView(
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: 24),
+            child: Column(
+              children: [
+                SizedBox(height: 24),
+                if (state.isLoading)
+                  const Center(child: CircularProgressIndicator()),
+                if (!state.isLoading && state.recipes.isEmpty)
+                  const Center(child: Text("저장된 레시피가 없습니다.")),
+                for (final recipe in state.recipes) ...[
+                  GestureDetector(
+                    onTap: () {
+                      context.push("/ingredient/${recipe.recipeId}");
+                    },
+                    child: RecipeCard(
+                      recipe: recipe,
+                      isBig: true,
+                      isBookmarked:
+                          state.bookMarkList.contains(recipe.recipeId)
+                              ? true
+                              : false,
+                      isIngredient: false,
+                      bookMarkCallback: () async {
+                        // await viewModel.bookmarkRecipe(recipe.recipeId);
+                        onAction(
+                          SavedRecipesAction.onTapBookmark(recipe.recipeId),
+                        );
+                      },
+                    ),
+                  ),
+                  SizedBox(height: 24),
+                ],
+              ],
             ),
           ),
-        );
-      },
+        ),
+      ),
     );
   }
 }

--- a/lib/presentation/saved_recipes/saved_recipes_screen.dart
+++ b/lib/presentation/saved_recipes/saved_recipes_screen.dart
@@ -35,7 +35,8 @@ class SavedRecipesScreen extends StatelessWidget {
                 for (final recipe in state.recipes) ...[
                   GestureDetector(
                     onTap: () {
-                      context.push("/ingredient/${recipe.recipeId}");
+                      // context.push("/ingredient/${recipe.recipeId}");
+                      onAction(SavedRecipesAction.onTapRecipe(recipe.recipeId));
                     },
                     child: RecipeCard(
                       recipe: recipe,

--- a/lib/presentation/saved_recipes/saved_recipes_screen_root.dart
+++ b/lib/presentation/saved_recipes/saved_recipes_screen_root.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:recipe_app/presentation/saved_recipes/saved_recipes_action.dart';
+import 'package:recipe_app/presentation/saved_recipes/saved_recipes_screen.dart';
+import 'package:recipe_app/presentation/saved_recipes/saved_recipes_view_model.dart';
+
+class SavedRecipesScreenRoot extends StatefulWidget {
+  final SavedRecipesViewModel viewModel;
+
+  const SavedRecipesScreenRoot({super.key, required this.viewModel});
+
+  @override
+  State<SavedRecipesScreenRoot> createState() => _SavedRecipesScreenRootState();
+}
+
+class _SavedRecipesScreenRootState extends State<SavedRecipesScreenRoot> {
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: widget.viewModel,
+      builder: (context, child) {
+        return SavedRecipesScreen(
+          state: widget.viewModel.state,
+          onAction: (action) {
+            switch (action) {
+              case OnTapRecipe():
+                context.push("/ingredient/${action.recipeId}");
+
+              case OnTapBookmark():
+                widget.viewModel.bookmarkRecipe(action.recipeId);
+            }
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/presentation/saved_recipes/saved_recipes_state.dart
+++ b/lib/presentation/saved_recipes/saved_recipes_state.dart
@@ -1,0 +1,13 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:recipe_app/domain/model/recipe.dart';
+
+part 'saved_recipes_state.freezed.dart';
+
+@freezed
+abstract class SavedRecipesState with _$SavedRecipesState{
+  const factory SavedRecipesState({
+    @Default([]) final List<Recipe> recipes,
+    @Default([]) final List<int> bookMarkList,
+    @Default(false) final bool isLoading,
+  }) = _SavedRecipesState;
+}

--- a/lib/presentation/saved_recipes/saved_recipes_view_model.dart
+++ b/lib/presentation/saved_recipes/saved_recipes_view_model.dart
@@ -13,15 +13,6 @@ class SavedRecipesViewModel with ChangeNotifier {
     fetchRecipes();
   }
 
-  // List<Recipe> _recipes = [];
-  // List<Recipe> get recipes => List.unmodifiable(_recipes);
-
-  // List<int> _bookMarkList = [];
-  // List<int> get bookMarkList => List.unmodifiable(_bookMarkList);
-
-  // bool _isLoading = false;
-  // bool get isLoading => _isLoading;
-
   SavedRecipesState _state = const SavedRecipesState();
   SavedRecipesState get state => _state;
 

--- a/lib/presentation/saved_recipes/saved_recipes_view_model.dart
+++ b/lib/presentation/saved_recipes/saved_recipes_view_model.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:recipe_app/domain/model/recipe.dart';
 import 'package:recipe_app/domain/use_case/get_saved_recipes_use_case.dart';
+import 'package:recipe_app/presentation/saved_recipes/saved_recipes_action.dart';
+import 'package:recipe_app/presentation/saved_recipes/saved_recipes_state.dart';
 
 class SavedRecipesViewModel with ChangeNotifier {
   final GetSavedRecipesUseCase _getSavedRecipesUseCase;
@@ -11,40 +13,59 @@ class SavedRecipesViewModel with ChangeNotifier {
     fetchRecipes();
   }
 
-  List<Recipe> _recipes = [];
-  List<Recipe> get recipes => List.unmodifiable(_recipes);
+  // List<Recipe> _recipes = [];
+  // List<Recipe> get recipes => List.unmodifiable(_recipes);
 
-  List<int> _bookMarkList = [];
-  List<int> get bookMarkList => List.unmodifiable(_bookMarkList);
+  // List<int> _bookMarkList = [];
+  // List<int> get bookMarkList => List.unmodifiable(_bookMarkList);
 
-  bool _isLoading = false;
-  bool get isLoading => _isLoading;
+  // bool _isLoading = false;
+  // bool get isLoading => _isLoading;
+
+  SavedRecipesState _state = const SavedRecipesState();
+  SavedRecipesState get state => _state;
+
+  void onAction(SavedRecipesAction action) {
+    switch (action) {
+      case OnTapRecipe():
+        break;
+      case OnTapBookmark():
+        throw UnimplementedError();
+    }
+  }
 
   Future<void> fetchRecipes() async {
-    _isLoading = true;
+    _state = _state.copyWith(isLoading: true);
     notifyListeners();
 
-    _recipes = await _getSavedRecipesUseCase.getSavedRecipes();
-    _bookMarkList = List.generate(
-      _recipes.length,
-      (index) => _recipes[index].recipeId,
+    final recipes = await _getSavedRecipesUseCase.getSavedRecipes();
+    final bookMarkList = List.generate(
+      recipes.length,
+      (index) => recipes[index].recipeId,
     );
-    _isLoading = false;
+    _state = _state.copyWith(
+      recipes: recipes,
+      bookMarkList: bookMarkList,
+      isLoading: false,
+    );
     notifyListeners();
   }
 
   Future<void> bookmarkRecipe(int recipeId) async {
-    _isLoading = true;
+    _state = _state.copyWith(isLoading: true);
     notifyListeners();
 
     // print("세이브 레시피 뷰모델.bookmarkRecipe 실행 recipeId : $recipeId");
     final bookmarkList = await _getSavedRecipesUseCase.setBookmark(4, recipeId);
-    _bookMarkList = bookmarkList;
     // print("북마크리스트 갱신 완료");
-    _recipes = await _getSavedRecipesUseCase.getSavedRecipes();
+    final recipes = await _getSavedRecipesUseCase.getSavedRecipes();
     // print("북마크 후 수정된 recipes : ${_recipes.map((e) => "${e.recipeId} :")}");
 
-    _isLoading = false;
+    _state = _state.copyWith(
+      recipes: recipes,
+      bookMarkList: bookmarkList,
+      isLoading: false,
+    );
     notifyListeners();
   }
 

--- a/lib/presentation/search_recipes/search_recipes_action.dart
+++ b/lib/presentation/search_recipes/search_recipes_action.dart
@@ -1,0 +1,9 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'search_recipes_action.freezed.dart';
+
+@freezed
+sealed class SearchRecipesAction with _$SearchRecipesAction{
+  const factory SearchRecipesAction.onValueChange(String value) = OnValueChange;
+  const factory SearchRecipesAction.onFilterTap() = OnFilterTap;
+}

--- a/lib/presentation/search_recipes/search_recipes_screen.dart
+++ b/lib/presentation/search_recipes/search_recipes_screen.dart
@@ -21,8 +21,12 @@ class _SearchRecipesScreenState extends State<SearchRecipesScreen> {
   @override
   void initState() {
     super.initState();
-    widget.viewModel.fetchAllRecipes();
-    widget.viewModel.whenOpenScreen();
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+      if (mounted) {
+        widget.viewModel.fetchAllRecipes();
+        widget.viewModel.whenOpenScreen();
+      }
+    });
   }
 
   @override
@@ -58,6 +62,7 @@ class _SearchRecipesScreenState extends State<SearchRecipesScreen> {
                                 value,
                               );
                             },
+                            onTap: () {},
                           ),
                         ),
                         FilterList(

--- a/lib/presentation/search_recipes/search_recipes_screen.dart
+++ b/lib/presentation/search_recipes/search_recipes_screen.dart
@@ -3,15 +3,19 @@ import 'package:recipe_app/domain/model/recipe.dart';
 import 'package:recipe_app/presentation/component/filter_list.dart';
 import 'package:recipe_app/presentation/component/input_field.dart';
 import 'package:recipe_app/presentation/component/recipe_card.dart';
-import 'package:recipe_app/presentation/search_recipes/filter_search_bottom_sheet.dart';
-import 'package:recipe_app/presentation/search_recipes/filter_search_view_model.dart';
-import 'package:recipe_app/presentation/search_recipes/search_recipes_view_model.dart';
+import 'package:recipe_app/presentation/search_recipes/search_recipes_action.dart';
+import 'package:recipe_app/presentation/search_recipes/search_recipes_state.dart';
 import 'package:recipe_app/ui/color_style.dart';
 import 'package:recipe_app/ui/text_style.dart';
 
 class SearchRecipesScreen extends StatefulWidget {
-  final SearchRecipesViewModel viewModel;
-  const SearchRecipesScreen({super.key, required this.viewModel});
+  final SearchRecipesState state;
+  final void Function(SearchRecipesAction action) onAction;
+  const SearchRecipesScreen({
+    super.key,
+    required this.state,
+    required this.onAction,
+  });
 
   @override
   State<SearchRecipesScreen> createState() => _SearchRecipesScreenState();
@@ -21,12 +25,6 @@ class _SearchRecipesScreenState extends State<SearchRecipesScreen> {
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-      if (mounted) {
-        widget.viewModel.fetchAllRecipes();
-        widget.viewModel.whenOpenScreen();
-      }
-    });
   }
 
   @override
@@ -39,96 +37,82 @@ class _SearchRecipesScreenState extends State<SearchRecipesScreen> {
         body: SingleChildScrollView(
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 30),
-            child: ListenableBuilder(
-              listenable: widget.viewModel,
-              builder: (context, child) {
-                return Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(height: 17),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
-                    SizedBox(height: 17),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        SizedBox(
-                          width: 260,
-                          child: InputField(
-                            label: '',
-                            placeHolder: 'Search recipe',
-                            isSearch: true,
-                            controller: TextEditingController(text: ''),
-                            onValueChange: (String value) async {
-                              await widget.viewModel.fetchSearchedRecipes(
-                                value,
-                              );
-                            },
-                            onTap: () {},
-                          ),
-                        ),
-                        FilterList(
-                          ontap: () {
-                            showModalBottomSheet(
-                              context: context,
-                              builder: (context) {
-                                return FilterSearchBottomSheet(
-                                  viewModel: FilterSearchViewModel(),
-                                  searchViewModel: widget.viewModel,
-                                );
-                              },
-                            );
-                          },
-                        ),
-                      ],
-                    ),
-                    SizedBox(height: 20),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text(
-                          widget.viewModel.state.isSearched
-                              ? "Search Result"
-                              : "Recent Search",
-                          style: TextStyles.normalTextBold,
-                        ),
-                        Text(
-                          widget.viewModel.state.isSearched
-                              ? "${widget.viewModel.state.recipeList.length} results"
-                              : "",
-                          style: TextStyles.smallTextRegular.copyWith(
-                            color: ColorStyles.gray3,
-                          ),
-                        ),
-                      ],
-                    ),
-                    SizedBox(height: 20),
-                    GridView.builder(
-                      shrinkWrap: true,
-                      physics: NeverScrollableScrollPhysics(),
-                      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                        crossAxisCount: 2,
-                        childAspectRatio: 1,
-                        mainAxisSpacing: 15,
-                        crossAxisSpacing: 15,
+                    SizedBox(
+                      width: 260,
+                      child: InputField(
+                        label: '',
+                        placeHolder: 'Search recipe',
+                        isSearch: true,
+                        controller: TextEditingController(text: ''),
+                        onValueChange: (String value) async {
+                          widget.onAction(
+                            SearchRecipesAction.onValueChange(value),
+                          );
+                        },
+                        onTap: () {},
                       ),
-                      itemCount: widget.viewModel.state.recipeList.length,
-                      itemBuilder: (context, index) {
-                        List<Recipe> recipes =
-                            widget.viewModel.state.recipeList;
-                        if (recipes.isEmpty) {
-                          return null;
-                        }
-                        return RecipeCard(
-                          recipe: recipes[index],
-                          isBig: false,
-                          isBookmarked: true,
-                          isIngredient: false,
-                          bookMarkCallback: () {},
-                        );
+                    ),
+                    FilterList(
+                      ontap: () {
+                        widget.onAction(SearchRecipesAction.onFilterTap());
                       },
                     ),
                   ],
-                );
-              },
+                ),
+                SizedBox(height: 20),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      widget.state.isSearched
+                          ? "Search Result"
+                          : "Recent Search",
+                      style: TextStyles.normalTextBold,
+                    ),
+                    Text(
+                      widget.state.isSearched
+                          ? "${widget.state.recipeList.length} results"
+                          : "",
+                      style: TextStyles.smallTextRegular.copyWith(
+                        color: ColorStyles.gray3,
+                      ),
+                    ),
+                  ],
+                ),
+                SizedBox(height: 20),
+                GridView.builder(
+                  shrinkWrap: true,
+                  physics: NeverScrollableScrollPhysics(),
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 2,
+                    childAspectRatio: 1,
+                    mainAxisSpacing: 15,
+                    crossAxisSpacing: 15,
+                  ),
+                  itemCount: widget.state.recipeList.length,
+                  itemBuilder: (context, index) {
+                    List<Recipe> recipes = widget.state.recipeList;
+                    if (recipes.isEmpty) {
+                      return null;
+                    }
+                    return RecipeCard(
+                      recipe: recipes[index],
+                      isBig: false,
+                      isBookmarked: true,
+                      isIngredient: false,
+                      bookMarkCallback: () {},
+                    );
+                  },
+                ),
+              ],
             ),
           ),
         ),

--- a/lib/presentation/search_recipes/search_recipes_screen_root.dart
+++ b/lib/presentation/search_recipes/search_recipes_screen_root.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:recipe_app/presentation/search_recipes/filter_search_bottom_sheet.dart';
+import 'package:recipe_app/presentation/search_recipes/filter_search_view_model.dart';
+import 'package:recipe_app/presentation/search_recipes/search_recipes_action.dart';
+import 'package:recipe_app/presentation/search_recipes/search_recipes_screen.dart';
+import 'package:recipe_app/presentation/search_recipes/search_recipes_view_model.dart';
+
+class SearchRecipesScreenRoot extends StatefulWidget {
+  final SearchRecipesViewModel viewModel;
+  const SearchRecipesScreenRoot({super.key, required this.viewModel});
+
+  @override
+  State<SearchRecipesScreenRoot> createState() =>
+      _SearchRecipesScreenRootState();
+}
+
+class _SearchRecipesScreenRootState extends State<SearchRecipesScreenRoot> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+      if (mounted) {
+        widget.viewModel.fetchAllRecipes();
+        widget.viewModel.whenOpenScreen();
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: widget.viewModel,
+      builder: (context, child) {
+        return SearchRecipesScreen(
+          state: widget.viewModel.state,
+          onAction: (action) {
+            switch (action) {
+              case OnFilterTap():
+                showModalBottomSheet(
+                  context: context,
+                  builder: (context) {
+                    return FilterSearchBottomSheet(
+                      viewModel: FilterSearchViewModel(),
+                      searchViewModel: widget.viewModel,
+                    );
+                  },
+                );
+              case OnValueChange():
+                widget.viewModel.fetchSearchedRecipes(action.value);
+            }
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/presentation/search_recipes/search_recipes_view_model.dart
+++ b/lib/presentation/search_recipes/search_recipes_view_model.dart
@@ -3,6 +3,7 @@ import 'package:recipe_app/domain/model/filter.dart';
 import 'package:recipe_app/domain/repository/recipe_repository.dart';
 import 'package:recipe_app/data/util/rate_enum.dart';
 import 'package:recipe_app/data/util/time_enum.dart';
+import 'package:recipe_app/presentation/search_recipes/search_recipes_action.dart';
 import 'package:recipe_app/presentation/search_recipes/search_recipes_state.dart';
 
 class SearchRecipesViewModel with ChangeNotifier {
@@ -14,6 +15,15 @@ class SearchRecipesViewModel with ChangeNotifier {
     : _recipeRepository = recipeRepository;
 
   SearchRecipesState get state => _state;
+
+  void onAction(SearchRecipesAction action) {
+    switch (action) {
+      case OnFilterTap():
+        break;
+      case OnValueChange():
+        fetchSearchedRecipes(action.value);
+    }
+  }
 
   void whenOpenScreen() {
     _state = _state.copyWith(isLoading: false, isSearched: false);

--- a/lib/presentation/sign_in/sign_in_screen.dart
+++ b/lib/presentation/sign_in/sign_in_screen.dart
@@ -38,6 +38,9 @@ class _SignInScreenState extends State<SignInScreen> {
                 isSearch: false,
                 onValueChange: (String value) {},
                 controller: TextEditingController(),
+                onTap: () {
+                  
+                },
               ),
               SizedBox(height: 30),
               InputField(
@@ -45,6 +48,9 @@ class _SignInScreenState extends State<SignInScreen> {
                 placeHolder: 'Enter Password',
                 isSearch: false,
                 onValueChange: (String value) {},
+                onTap: () {
+                  
+                },
                 controller: TextEditingController(),
               ),
               SizedBox(height: 20),

--- a/lib/presentation/sign_in/sign_in_screen.dart
+++ b/lib/presentation/sign_in/sign_in_screen.dart
@@ -1,14 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:http/http.dart' as http;
 import 'package:recipe_app/core/routing/routes.dart';
-import 'package:recipe_app/data/data_source/mock_recipe_data_source.dart';
-import 'package:recipe_app/data/repository/mock_recipe_repository_impl.dart';
-import 'package:recipe_app/presentation/bottom_navigation_bar/bottom_navigation_bar_screen.dart';
 import 'package:recipe_app/presentation/component/big_button.dart';
 import 'package:recipe_app/presentation/component/input_field.dart';
-import 'package:recipe_app/presentation/home/home_screen.dart';
-import 'package:recipe_app/presentation/search_recipes/search_recipes_view_model.dart';
 import 'package:recipe_app/ui/color_style.dart';
 import 'package:recipe_app/ui/text_style.dart';
 
@@ -38,9 +32,7 @@ class _SignInScreenState extends State<SignInScreen> {
                 isSearch: false,
                 onValueChange: (String value) {},
                 controller: TextEditingController(),
-                onTap: () {
-                  
-                },
+                onTap: () {},
               ),
               SizedBox(height: 30),
               InputField(
@@ -48,9 +40,7 @@ class _SignInScreenState extends State<SignInScreen> {
                 placeHolder: 'Enter Password',
                 isSearch: false,
                 onValueChange: (String value) {},
-                onTap: () {
-                  
-                },
+                onTap: () {},
                 controller: TextEditingController(),
               ),
               SizedBox(height: 20),

--- a/lib/presentation/sign_up/sign_up_screen.dart
+++ b/lib/presentation/sign_up/sign_up_screen.dart
@@ -40,6 +40,9 @@ class _SignUpScreenState extends State<SignUpScreen> {
                   placeHolder: 'Enter Name',
                   isSearch: false,
                   onValueChange: (String value) {},
+                  onTap: () {
+                  
+                },
                   controller: TextEditingController(),
                 ),
                 SizedBox(height: 20),
@@ -48,6 +51,9 @@ class _SignUpScreenState extends State<SignUpScreen> {
                   placeHolder: 'Enter Email',
                   isSearch: false,
                   onValueChange: (String value) {},
+                  onTap: () {
+                    
+                  },
                   controller: TextEditingController(),
                 ),
                 SizedBox(height: 20),
@@ -56,6 +62,9 @@ class _SignUpScreenState extends State<SignUpScreen> {
                   placeHolder: 'Enter Password',
                   isSearch: false,
                   onValueChange: (String value) {},
+                  onTap: () {
+                    
+                  },
                   controller: TextEditingController(),
                 ),
                 SizedBox(height: 20),
@@ -64,6 +73,9 @@ class _SignUpScreenState extends State<SignUpScreen> {
                   placeHolder: 'Retype Password',
                   isSearch: false,
                   onValueChange: (String value) {},
+                  onTap: () {
+                    
+                  },
                   controller: TextEditingController(),
                 ),
                 SizedBox(height: 20),

--- a/lib/test_screen/component_test_screen.dart
+++ b/lib/test_screen/component_test_screen.dart
@@ -13,6 +13,7 @@ import 'package:recipe_app/presentation/component/input_field.dart';
 
 import 'package:recipe_app/presentation/component/tabs.dart';
 import 'package:recipe_app/presentation/saved_recipes/saved_recipes_screen.dart';
+import 'package:recipe_app/presentation/saved_recipes/saved_recipes_screen_root.dart';
 import 'package:recipe_app/presentation/saved_recipes/saved_recipes_view_model.dart';
 import 'package:recipe_app/presentation/search_recipes/search_recipes_screen.dart';
 import 'package:recipe_app/presentation/search_recipes/search_recipes_view_model.dart';
@@ -47,7 +48,7 @@ class ComponentTestScreen extends StatelessWidget {
                         MaterialPageRoute(
                           builder:
                               (context) =>
-                                  SavedRecipesScreen(viewModel: getIt()),
+                                  SavedRecipesScreenRoot(viewModel: getIt()),
                         ),
                       );
                     },
@@ -149,6 +150,7 @@ class ComponentTestScreen extends StatelessWidget {
                     onValueChange: (value) {
                       print('입력이 변경되었습니다.');
                     },
+                    onTap: () {},
                   ),
                   SizedBox(height: 12),
                   InputField(
@@ -159,6 +161,7 @@ class ComponentTestScreen extends StatelessWidget {
                     onValueChange: (value) {
                       print('입력이 변경되었습니다.');
                     },
+                    onTap: () {},
                   ),
                   SizedBox(height: 12),
                   Tabs(

--- a/lib/test_screen/component_test_screen.dart
+++ b/lib/test_screen/component_test_screen.dart
@@ -16,6 +16,7 @@ import 'package:recipe_app/presentation/saved_recipes/saved_recipes_screen.dart'
 import 'package:recipe_app/presentation/saved_recipes/saved_recipes_screen_root.dart';
 import 'package:recipe_app/presentation/saved_recipes/saved_recipes_view_model.dart';
 import 'package:recipe_app/presentation/search_recipes/search_recipes_screen.dart';
+import 'package:recipe_app/presentation/search_recipes/search_recipes_screen_root.dart';
 import 'package:recipe_app/presentation/search_recipes/search_recipes_view_model.dart';
 import 'package:recipe_app/presentation/splash/splash_screen.dart';
 import 'package:recipe_app/test_screen/button_screen.dart';
@@ -77,7 +78,7 @@ class ComponentTestScreen extends StatelessWidget {
                         MaterialPageRoute(
                           builder:
                               (context) =>
-                                  SearchRecipesScreen(viewModel: getIt()),
+                                  SearchRecipesScreenRoot(viewModel: getIt()),
                         ),
                       );
                     },

--- a/test/widget_test/component_test.dart
+++ b/test/widget_test/component_test.dart
@@ -71,6 +71,9 @@ void main() {
             isSearch: false,
             controller: TextEditingController(),
             onValueChange: (value) => updatedValue = value,
+            onTap: () {
+              
+            },
           ),
         ),
       ),


### PR DESCRIPTION
# 250422_14_김동성

## 📝 과제 정보

고급 상태관리 기법

## ✅ 구현 내용

Recipe앱 스크린 루트와 분리

## 📋 체크리스트

- [ ] 과제 코드 작성


## 🔍 구현 방법

스크린을 루트와 분리하고, 스크린에는 상태와 액션을 넣어준다.

## 🚨 어려웠던 점

Action을 freezed를 이용해 sealed클래스로 만들고 root스크린에서 이용할때 swtich-case문에서 action.recipeId처럼 내가 선언하지 않은 필드값이 이용가능한게 이해가 안가서 몇시간을 해맸다.
화면이동하는 액션이 있을경우 viewModel에서 onAction을 어떻게 구현해야 할지 모르겠다.

## 💡 배운 점

스크린을 루트와 분리하고 콜백함수를 이용해 액션을 모두 뺐을때 테스트가 가능해진다.

## ❓ 질문 사항

클릭시 화면을 이동하는 경우 viewModel에서 onAction을 어떻게 구현해야 할지 모르겠습니다.

## 🔄 자체 평가 & 회고

개념자체는 이해가 되는거 같은데 코드로 어떻게 작성하는건지 모르겠다ㅠㅠ 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 검색, 저장 레시피, 재료 관련 화면에 상태 및 액션 클래스를 도입하여 UI와 로직 분리
  - `IngredientScreenRoot`, `SavedRecipesScreenRoot`, `SearchRecipesScreenRoot` 등 Root 위젯 추가로 상태 관리 및 액션 처리 구조 개선
  - 입력 필드(`InputField`)에 탭 이벤트 콜백(`onTap`) 추가

- **리팩터링**
  - 각 화면에서 ViewModel 기반 상태 관리에서 불변 상태(State) 및 액션(Action) 기반 구조로 전환
  - 내부 라우팅 및 위젯 구조를 Root 위젯 중심으로 변경하여 유지보수성 향상

- **버그 수정**
  - 탭 인덱스 변경 시 UI 갱신이 누락되는 문제 수정

- **테스트**
  - 테스트 및 테스트 스크린의 입력 필드에 `onTap` 콜백 추가

- **기타**
  - 불필요한 import 및 사용하지 않는 코드 정리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->